### PR TITLE
Correct net income calculations for player and children

### DIFF
--- a/src/people/classes/child.py
+++ b/src/people/classes/child.py
@@ -124,7 +124,7 @@ class Child(Relationship):
             tax = calculate_tax(self.salary)
             income = self.salary - tax
             income *= random.uniform(0.4, 0.8)
-            self.money += round_stochastic(self.salary)
+            self.money += round_stochastic(income)
         can_get_job = self.salary == 0 and self.age >= 18 and self.is_in_uv == 0
         if can_get_job and randint(1, 3) == 1:
             attempts = randint(2, 7)

--- a/src/people/classes/player.py
+++ b/src/people/classes/player.py
@@ -783,7 +783,7 @@ class Player(Person):
 		if self.salary > 0:
 			money = self.salary * self.job_hours / 40
 			tax = calculate_tax(money)
-			income = self.salary - tax
+			income = money - tax
 			income *= random.uniform(0.4, 0.8)  # Expenses
 			self.money += round_stochastic(income)
 		if self.uv_years > 0:

--- a/tests/test_income.py
+++ b/tests/test_income.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import random
+import builtins
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+builtins.input = lambda: "1"
+
+partner_stub = types.ModuleType("partner")
+class _DummyPartner:
+    pass
+partner_stub.Partner = _DummyPartner
+sys.modules['src.people.classes.partner'] = partner_stub
+
+from src.people.classes.player import Player
+from src.lifesim_lib.lifesim_lib import Gender, calculate_tax, round_stochastic
+
+
+def test_player_income_respects_hours_and_tax():
+    random.seed(1)
+    p = Player(first="Test", last="User", gender=Gender.Male)
+    p.age = 0
+    p.salary = 52000
+    p.has_job = True
+    p.job_hours = 20
+    p.money = 0
+    p.years_worked = 0
+
+    random.seed(2)
+    p.random_events()
+
+    random.seed(2)
+    factor = random.uniform(0.4, 0.8)
+    money = p.salary * p.job_hours / 40
+    tax = calculate_tax(money)
+    income = money - tax
+    income *= factor
+    expected = round_stochastic(income)
+    assert p.money == expected


### PR DESCRIPTION
## Summary
- Fix salary handling to base earnings on actual hours worked and tax
- Ensure child income adds net earnings after tax and expenses
- Add regression test for part-time job income calculation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f2e02312c832f9db9432b6f108127