### PR TITLE
Add basic job types and titles

### DIFF
--- a/src/lifesim_lib/const.py
+++ b/src/lifesim_lib/const.py
@@ -20,6 +20,15 @@ SALARY_TAX_BRACKETS = [
 
 from src.lifesim_lib.translation import _
 
+# Basic job types available when searching for employment. Each entry is a
+# tuple of the form (title, minimum salary, average salary). The salary is
+# generated exponentially between the two numbers.
+JOB_TYPES = [
+    (_("Janitor"), 30000, 40000),
+    (_("Teacher"), 35000, 50000),
+    (_("Software Developer"), 60000, 90000),
+]
+
 ILLNESSES_TRANSLATIONS = {
     "Depression": _("Depression"),
     "High Blood Pressure": _("High Blood Pressure"),

--- a/src/menus/main.py
+++ b/src/menus/main.py
@@ -17,12 +17,13 @@ def main_menu(player):
 	display_data(_("Your name"), player.name)
 	t = player.get_traits_str() if player.traits else "None"
 	display_data(_("Traits"), t)
-	display_data(_("Gender"), player.get_gender_str())
-	display_data(_("Money"), f"${player.money:,}")
-	if player.salary > 0:
-		print(_("Salary") + f": ${player.salary:,}")
-	if player.generation > 1:
-		display_data(_("Generation"), player.generation)
+        display_data(_("Gender"), player.get_gender_str())
+        display_data(_("Money"), f"${player.money:,}")
+        if player.has_job:
+                display_data(_("Job Title"), player.job_title)
+                display_data(_("Salary"), f"${player.salary:,}")
+        if player.generation > 1:
+                display_data(_("Generation"), player.generation)
 	player.display_stats()
 	print()
 	choices = [_("Age +1"), _("Relationships"), _("Activities")]
@@ -634,45 +635,52 @@ def main_menu(player):
 						player.gender = Gender.Female
 					else:
 						player.gender = Gender.Male
-	if choice == _("Find a Job"):
-		salary = round_stochastic(
-			randexpo(30000, 65000)
-		)  # TODO: Add a selection of different types of jobs
-		if yes_no(
-			_(
-				"You found a job with a salary of ${salary:,}. Would you like to apply?"
-			).format(salary=salary)
-		):
-			m = 100 + round_stochastic((salary - 40000) / 300)
-			mod = (
-				50 - player.smarts
-			)  # Mod is inverted because we want to roll 100 OR LOWER to get the job
-			if randint(1, 3) == 1:
-				mod += round((50 - player.karma) / 2)
-			roll = randint(1, m)
-			if mod > 0:
-				roll += randint(0, mod)
-			elif mod < 0:
-				roll -= randint(0, abs(mod))
-			if roll <= 100:
-				print(_("You got the job!"))
-				player.change_happiness(4)
-				player.get_job(salary)
-			else:
-				print(_("You didn't get an interview."))
-				player.change_happiness(-randint(1, 4))
-		else:
-			clear_screen()
-	elif choice == _("Job Menu"):
-		print(_("Your job"))
-		print()
-		print_align_bars(
-			(_("Stress"), player.stress), (_("Performance"), player.performance)
-		)
-		display_data(_("Hours"), player.job_hours)
-		can_retire = player.years_worked >= 10 and player.age >= 65
-		choice = choice_input(
-			_("Back"),
+        if choice == _("Find a Job"):
+                offers = random.sample(JOB_TYPES, min(3, len(JOB_TYPES)))
+                jobs = []
+                options = [_("Back")]
+                for title, lo, avg in offers:
+                        salary = round_stochastic(randexpo(lo, avg))
+                        jobs.append((title, salary))
+                        options.append(f"{title} (${salary:,})")
+                job_choice = choice_input(*options)
+                if job_choice != 1:
+                        title, salary = jobs[job_choice - 2]
+                        if yes_no(
+                                _(
+                                        "You found a job as a {title} with a salary of ${salary:,}. Would you like to apply?"
+                                ).format(title=title, salary=salary)
+                        ):
+                                m = 100 + round_stochastic((salary - 40000) / 300)
+                                mod = 50 - player.smarts
+                                if randint(1, 3) == 1:
+                                        mod += round((50 - player.karma) / 2)
+                                roll = randint(1, m)
+                                if mod > 0:
+                                        roll += randint(0, mod)
+                                elif mod < 0:
+                                        roll -= randint(0, abs(mod))
+                                if roll <= 100:
+                                        print(_("You got the job!"))
+                                        player.change_happiness(4)
+                                        player.get_job(salary, title)
+                                else:
+                                        print(_("You didn't get an interview."))
+                                        player.change_happiness(-randint(1, 4))
+                        else:
+                                clear_screen()
+        elif choice == _("Job Menu"):
+                print(_("Your job"))
+                print()
+                display_data(_("Job Title"), player.job_title)
+                display_data(_("Salary"), f"${player.salary:,}")
+                print_align_bars(
+                        (_("Stress"), player.stress), (_("Performance"), player.performance)
+                )
+                display_data(_("Hours"), player.job_hours)
+                can_retire = player.years_worked >= 10 and player.age >= 65
+                choice = choice_input(
+                        _("Back"),
 			_("Work Harder"),
 			_("Retire") if can_retire else _("Quit Job"),
 			_("Adjust Hours"),

--- a/src/people/classes/player.py
+++ b/src/people/classes/player.py
@@ -74,6 +74,7 @@ class Player(Person):
 		self.salary = 0
 		self.years_worked = 0
 		self.has_job = False
+		self.job_title = None
 		self.lottery_jackpot = 0
 		self.stress = 0
 		self.performance = 0
@@ -640,10 +641,11 @@ class Player(Person):
 					self.change_health(-randint(4, 8))
 					self.add_illness(TranslateMarker("High Blood Pressure"))
 
-	def get_job(self, salary):
+	def get_job(self, salary, title=None):
 		if not self.has_job:
 			self.has_job = True
 			self.salary = salary
+			self.job_title = title
 			self.years_worked = 0
 			self.stress = 45
 			self.performance = 50
@@ -656,12 +658,12 @@ class Player(Person):
 		if self.has_job:
 			self.has_job = False
 			self.salary = 0
+			self.job_title = None
 			self.years_worked = 0
 			self.stress = 0
 			self.performance = 0
 			self.job_hours = 0
 			self.salary_years = []
-
 	def change_stress(self, amount):
 		if self.has_job:
 			self.stress = clamp(self.stress + amount, 0, 100)

--- a/src/people/classes/relationship.py
+++ b/src/people/classes/relationship.py
@@ -17,7 +17,13 @@ class Relationship(Person):
         self.had_conversation = False
         self.was_complimented = False
 
-    # TODO: add is_male() and is_female() methods
+    def is_male(self):
+        """Return True if this relation is male."""
+        return self.gender == Gender.Male
+
+    def is_female(self):
+        """Return True if this relation is female."""
+        return self.gender == Gender.Female
 
     def change_relationship(self, amount):
         self.relationship = clamp(self.relationship + amount, 0, 100)

--- a/tests/test_job_titles.py
+++ b/tests/test_job_titles.py
@@ -1,0 +1,12 @@
+from src.people.classes.player import Player
+from src.lifesim_lib.lifesim_lib import Gender
+
+def test_get_job_sets_title_and_resets():
+    p = Player(first="Test", last="User", gender=Gender.Male)
+    p.get_job(50000, "Teacher")
+    assert p.has_job
+    assert p.salary == 50000
+    assert p.job_title == "Teacher"
+    p.lose_job()
+    assert not p.has_job
+    assert p.job_title is None


### PR DESCRIPTION
## Summary
- add predefined job categories and support selecting job titles with salaries
- track player job title and show it in menus
- expose relationship gender helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f38821948832f8a5c0085cf05f2f0