### PR TITLE
Add goal system to guide player progression

### DIFF
--- a/src/lifesim_lib/goal.py
+++ b/src/lifesim_lib/goal.py
@@ -1,0 +1,15 @@
+class Goal:
+    """Represents a player goal."""
+
+    def __init__(self, description, complete_func, progress_func=None):
+        self.description = description
+        self.complete_func = complete_func
+        self.progress_func = progress_func
+
+    def is_complete(self, player):
+        return bool(self.complete_func(player))
+
+    def progress(self, player):
+        if self.progress_func:
+            return self.progress_func(player)
+        return None

--- a/src/menus/main.py
+++ b/src/menus/main.py
@@ -13,17 +13,24 @@ from src.people.classes.child import Child
 from src.menus.activities import activities_menu
 
 def main_menu(player):
+	player.check_goals()
 	print()
 	display_data(_("Your name"), player.name)
 	t = player.get_traits_str() if player.traits else "None"
 	display_data(_("Traits"), t)
-        display_data(_("Gender"), player.get_gender_str())
-        display_data(_("Money"), f"${player.money:,}")
-        if player.has_job:
-                display_data(_("Job Title"), player.job_title)
-                display_data(_("Salary"), f"${player.salary:,}")
-        if player.generation > 1:
-                display_data(_("Generation"), player.generation)
+	display_data(_("Gender"), player.get_gender_str())
+	display_data(_("Money"), f"${player.money:,}")
+	if player.has_job:
+		display_data(_("Job Title"), player.job_title)
+		display_data(_("Salary"), f"${player.salary:,}")
+	if player.generation > 1:
+		display_data(_("Generation"), player.generation)
+	current_goal = player.get_current_goal()
+	if current_goal:
+		display_data(_("Current Goal"), current_goal.description)
+		progress = player.get_goal_progress()
+		if progress:
+			display_data(_("Progress"), progress)
 	player.display_stats()
 	print()
 	choices = [_("Age +1"), _("Relationships"), _("Activities")]
@@ -635,52 +642,52 @@ def main_menu(player):
 						player.gender = Gender.Female
 					else:
 						player.gender = Gender.Male
-        if choice == _("Find a Job"):
-                offers = random.sample(JOB_TYPES, min(3, len(JOB_TYPES)))
-                jobs = []
-                options = [_("Back")]
-                for title, lo, avg in offers:
-                        salary = round_stochastic(randexpo(lo, avg))
-                        jobs.append((title, salary))
-                        options.append(f"{title} (${salary:,})")
-                job_choice = choice_input(*options)
-                if job_choice != 1:
-                        title, salary = jobs[job_choice - 2]
-                        if yes_no(
-                                _(
-                                        "You found a job as a {title} with a salary of ${salary:,}. Would you like to apply?"
-                                ).format(title=title, salary=salary)
-                        ):
-                                m = 100 + round_stochastic((salary - 40000) / 300)
-                                mod = 50 - player.smarts
-                                if randint(1, 3) == 1:
-                                        mod += round((50 - player.karma) / 2)
-                                roll = randint(1, m)
-                                if mod > 0:
-                                        roll += randint(0, mod)
-                                elif mod < 0:
-                                        roll -= randint(0, abs(mod))
-                                if roll <= 100:
-                                        print(_("You got the job!"))
-                                        player.change_happiness(4)
-                                        player.get_job(salary, title)
-                                else:
-                                        print(_("You didn't get an interview."))
-                                        player.change_happiness(-randint(1, 4))
-                        else:
-                                clear_screen()
-        elif choice == _("Job Menu"):
-                print(_("Your job"))
-                print()
-                display_data(_("Job Title"), player.job_title)
-                display_data(_("Salary"), f"${player.salary:,}")
-                print_align_bars(
-                        (_("Stress"), player.stress), (_("Performance"), player.performance)
-                )
-                display_data(_("Hours"), player.job_hours)
-                can_retire = player.years_worked >= 10 and player.age >= 65
-                choice = choice_input(
-                        _("Back"),
+	if choice == _("Find a Job"):
+		offers = random.sample(JOB_TYPES, min(3, len(JOB_TYPES)))
+		jobs = []
+		options = [_("Back")]
+		for title, lo, avg in offers:
+			salary = round_stochastic(randexpo(lo, avg))
+			jobs.append((title, salary))
+			options.append(f"{title} (${salary:,})")
+		job_choice = choice_input(*options)
+		if job_choice != 1:
+			title, salary = jobs[job_choice - 2]
+			if yes_no(
+				_(
+				        "You found a job as a {title} with a salary of ${salary:,}. Would you like to apply?"
+				).format(title=title, salary=salary)
+			):
+				m = 100 + round_stochastic((salary - 40000) / 300)
+				mod = 50 - player.smarts
+				if randint(1, 3) == 1:
+				        mod += round((50 - player.karma) / 2)
+				roll = randint(1, m)
+				if mod > 0:
+				        roll += randint(0, mod)
+				elif mod < 0:
+				        roll -= randint(0, abs(mod))
+				if roll <= 100:
+				        print(_("You got the job!"))
+				        player.change_happiness(4)
+				        player.get_job(salary, title)
+				else:
+				        print(_("You didn't get an interview."))
+				        player.change_happiness(-randint(1, 4))
+			else:
+				clear_screen()
+	elif choice == _("Job Menu"):
+		print(_("Your job"))
+		print()
+		display_data(_("Job Title"), player.job_title)
+		display_data(_("Salary"), f"${player.salary:,}")
+		print_align_bars(
+			(_("Stress"), player.stress), (_("Performance"), player.performance)
+		)
+		display_data(_("Hours"), player.job_hours)
+		can_retire = player.years_worked >= 10 and player.age >= 65
+		choice = choice_input(
+			_("Back"),
 			_("Work Harder"),
 			_("Retire") if can_retire else _("Quit Job"),
 			_("Adjust Hours"),

--- a/src/people/classes/player.py
+++ b/src/people/classes/player.py
@@ -4,6 +4,7 @@ from random import randint, gauss
 from src.lifesim_lib.const import *
 from src.lifesim_lib.translation import _
 from src.lifesim_lib.lifesim_lib import *
+from src.lifesim_lib.goal import Goal
 from src.people.classes.parent import Parent
 from src.people.classes.person import Person
 from src.people.classes.sibling import Sibling
@@ -101,6 +102,55 @@ class Player(Person):
 		self.update_plastic_surgeon(0)
 		self.update_plastic_surgeon(1)
 		self.social_media = None
+		self.goals = [
+			Goal(
+				_("Reach adulthood (age 18)"),
+				lambda p: p.age >= 18,
+				lambda p: f"{p.age}/18",
+			),
+			Goal(
+				_("Get a job"),
+				lambda p: p.has_job,
+				lambda p: _("Employed") if p.has_job else _("Unemployed"),
+			),
+			Goal(
+				_("Accumulate $100,000"),
+				lambda p: p.money >= 100_000,
+				lambda p: f"${p.money:,}/100,000",
+			),
+		]
+		self.current_goal_index = 0
+
+	def get_current_goal(self):
+		if self.current_goal_index < len(self.goals):
+			return self.goals[self.current_goal_index]
+		return None
+
+	def get_goal_description(self):
+		goal = self.get_current_goal()
+		if goal:
+			return goal.description
+		return _("All goals completed!")
+
+	def get_goal_progress(self):
+		goal = self.get_current_goal()
+		if goal:
+			prog = goal.progress(self)
+			if prog is not None:
+				return prog
+		return ""
+
+	def check_goals(self):
+		while self.current_goal_index < len(self.goals):
+			goal = self.goals[self.current_goal_index]
+			if goal.is_complete(self):
+				print(_("Goal complete: {goal}").format(goal=goal.description))
+				self.current_goal_index += 1
+				if self.current_goal_index < len(self.goals):
+					next_goal = self.goals[self.current_goal_index].description
+					print(_("New goal: {goal}").format(goal=next_goal))
+			else:
+				break
 
 	def learn_trait(self, trait):
 		if trait not in TRAITS_DICT:


### PR DESCRIPTION
## Summary
- add a `Goal` utility and track player goals
- show current goal and progress in the main menu
- notify when goals are completed and new goals begin

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68900726468c832f90a21a95390ae7e2