### PR TITLE
Fix save crash caused by unpickleable goals

### DIFF
--- a/src/people/classes/player.py
+++ b/src/people/classes/player.py
@@ -352,7 +352,9 @@ class Player(Person):
 	def save_game(self):
 		if not os.path.exists(self.save_path):
 			open(self.save_path, "x")
-		pickle.dump(self.__dict__, open(self.save_path, "wb"))
+		data = self.__dict__.copy()
+		data.pop("goals", None)
+		pickle.dump(data, open(self.save_path, "wb"))
 
 	def delete_save(self):
 		if os.path.exists(self.save_path):


### PR DESCRIPTION
## Summary
- avoid pickling `goals` list that contains lambdas

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68904403dbf8832fbe30e0220308f9ab