### PR TITLE
Add pre-primary activities

### DIFF
--- a/lifesim.pot
+++ b/lifesim.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2022-12-01 18:01-0500\n"
+"POT-Creation-Date: 2025-08-04 10:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -27,7 +27,7 @@ msgstr ""
 msgid "Please report this bug on Github"
 msgstr ""
 
-#: lifesim.py:42 src/people/classes/player.py:432
+#: lifesim.py:42 src/people/classes/player.py:608
 msgid "Age {age}"
 msgstr ""
 
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Ethiopia"
 msgstr ""
 
-#: src/countries/countries.py:63 src/lifesim_lib/const.py:1582
+#: src/countries/countries.py:63 src/lifesim_lib/const.py:1591
 msgid "Fiji"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgstr ""
 msgid "The Gambia"
 msgstr ""
 
-#: src/countries/countries.py:68 src/lifesim_lib/const.py:4240
+#: src/countries/countries.py:68 src/lifesim_lib/const.py:4249
 msgid "Georgia"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 msgid "Iceland"
 msgstr ""
 
-#: src/countries/countries.py:81 src/lifesim_lib/const.py:1565
+#: src/countries/countries.py:81 src/lifesim_lib/const.py:1574
 msgid "India"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr ""
 msgid "Netherlands"
 msgstr ""
 
-#: src/countries/countries.py:130 src/lifesim_lib/const.py:1587
+#: src/countries/countries.py:130 src/lifesim_lib/const.py:1596
 msgid "New Zealand"
 msgstr ""
 
@@ -563,7 +563,7 @@ msgstr ""
 msgid "Niger"
 msgstr ""
 
-#: src/countries/countries.py:133 src/lifesim_lib/const.py:1588
+#: src/countries/countries.py:133 src/lifesim_lib/const.py:1597
 msgid "Nigeria"
 msgstr ""
 
@@ -791,7 +791,7 @@ msgstr ""
 msgid "United Kingdom"
 msgstr ""
 
-#: src/countries/countries.py:190 src/lifesim_lib/const.py:1629
+#: src/countries/countries.py:190 src/lifesim_lib/const.py:1638
 msgid "United States"
 msgstr ""
 
@@ -831,13589 +831,13598 @@ msgstr ""
 msgid "Zimbabwe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:24 src/people/classes/player.py:535
-msgid "Depression"
-msgstr ""
-
-#: src/lifesim_lib/const.py:25 src/people/classes/player.py:611
-msgid "High Blood Pressure"
-msgstr ""
-
-#: src/lifesim_lib/const.py:29
-msgid "a boss"
-msgstr ""
-
-#: src/lifesim_lib/const.py:30
-msgid "a bubbly personality"
-msgstr ""
-
-#: src/lifesim_lib/const.py:31
-msgid "a brilliant mind"
-msgstr ""
-
-#: src/lifesim_lib/const.py:32
-msgid "a champion"
-msgstr ""
-
-#: src/lifesim_lib/const.py:33
-msgid "a gem"
-msgstr ""
-
-#: src/lifesim_lib/const.py:34
-msgid "a genius"
-msgstr ""
-
-#: src/lifesim_lib/const.py:35
-msgid "a jewel"
-msgstr ""
-
-#: src/lifesim_lib/const.py:36
-msgid "a legend"
-msgstr ""
-
-#: src/lifesim_lib/const.py:37
-msgid "a player"
-msgstr ""
-
-#: src/lifesim_lib/const.py:38
-msgid "a revolutionary"
-msgstr ""
-
-#: src/lifesim_lib/const.py:39
-msgid "a smart cookie"
-msgstr ""
-
-#: src/lifesim_lib/const.py:40
-msgid "a treasure"
-msgstr ""
-
-#: src/lifesim_lib/const.py:41
-msgid "a winner"
-msgstr ""
-
-#: src/lifesim_lib/const.py:42
-msgid "a wizard"
-msgstr ""
-
-#: src/lifesim_lib/const.py:43
-msgid "a VIP"
-msgstr ""
-
-#: src/lifesim_lib/const.py:44
-msgid "a visionary"
-msgstr ""
-
-#: src/lifesim_lib/const.py:45
-msgid "adorable"
-msgstr ""
-
-#: src/lifesim_lib/const.py:46
-msgid "admirable"
-msgstr ""
-
-#: src/lifesim_lib/const.py:47
-msgid "an OG"
-msgstr ""
-
-#: src/lifesim_lib/const.py:48
-msgid "an eager beaver"
-msgstr ""
-
-#: src/lifesim_lib/const.py:49
-msgid "brave"
-msgstr ""
-
-#: src/lifesim_lib/const.py:50
-msgid "bright"
-msgstr ""
-
-#: src/lifesim_lib/const.py:51
-msgid "brilliant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:52
-msgid "charming"
-msgstr ""
-
-#: src/lifesim_lib/const.py:53
-msgid "clever"
-msgstr ""
-
-#: src/lifesim_lib/const.py:54
-msgid "cool"
-msgstr ""
-
-#: src/lifesim_lib/const.py:55
-msgid "courageous"
-msgstr ""
-
-#: src/lifesim_lib/const.py:56
-msgid "cute"
-msgstr ""
-
-#: src/lifesim_lib/const.py:57
-msgid "dashing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:58
-msgid "delightful"
-msgstr ""
-
-#: src/lifesim_lib/const.py:59
-msgid "dope"
-msgstr ""
-
-#: src/lifesim_lib/const.py:60
-msgid "elite"
-msgstr ""
-
-#: src/lifesim_lib/const.py:61
-msgid "fascinating"
-msgstr ""
-
-#: src/lifesim_lib/const.py:62
-msgid "fearless"
-msgstr ""
-
-#: src/lifesim_lib/const.py:63
-msgid "fine"
-msgstr ""
-
-#: src/lifesim_lib/const.py:64
-msgid "fresh"
-msgstr ""
-
-#: src/lifesim_lib/const.py:65
-msgid "gorgeous"
-msgstr ""
-
-#: src/lifesim_lib/const.py:66
-msgid "golden"
-msgstr ""
-
-#: src/lifesim_lib/const.py:67
-msgid "groovy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:68
-msgid "inspiring"
-msgstr ""
-
-#: src/lifesim_lib/const.py:69
-msgid "intelligent"
-msgstr ""
-
-#: src/lifesim_lib/const.py:70
-msgid "legendary"
-msgstr ""
-
-#: src/lifesim_lib/const.py:71
-msgid "lionhearted"
-msgstr ""
-
-#: src/lifesim_lib/const.py:72
-msgid "magnetic"
-msgstr ""
-
-#: src/lifesim_lib/const.py:73
-msgid "magnificent"
-msgstr ""
-
-#: src/lifesim_lib/const.py:74
-msgid "motivating"
-msgstr ""
-
-#: src/lifesim_lib/const.py:75
-msgid "neat"
-msgstr ""
-
-#: src/lifesim_lib/const.py:76
-msgid "nifty"
-msgstr ""
-
-#: src/lifesim_lib/const.py:77
-msgid "one-of-a-kind"
-msgstr ""
-
-#: src/lifesim_lib/const.py:78
-msgid "a perfect 10"
-msgstr ""
-
-#: src/lifesim_lib/const.py:79
-msgid "phenomenal"
-msgstr ""
-
-#: src/lifesim_lib/const.py:80
-msgid "rad"
-msgstr ""
-
-#: src/lifesim_lib/const.py:81
-msgid "savage"
-msgstr ""
-
-#: src/lifesim_lib/const.py:82
-msgid "smart"
-msgstr ""
-
-#: src/lifesim_lib/const.py:83
-msgid "spectatular"
-msgstr ""
-
-#: src/lifesim_lib/const.py:84
-msgid "stellar"
-msgstr ""
-
-#: src/lifesim_lib/const.py:85
-msgid "strong"
-msgstr ""
-
-#: src/lifesim_lib/const.py:86
-msgid "stunning"
-msgstr ""
-
-#: src/lifesim_lib/const.py:87
-msgid "stylish"
-msgstr ""
-
-#: src/lifesim_lib/const.py:88
-msgid "swell"
-msgstr ""
-
-#: src/lifesim_lib/const.py:89
-msgid "the best"
-msgstr ""
-
-#: src/lifesim_lib/const.py:90
-msgid "the GOAT"
-msgstr ""
-
-#: src/lifesim_lib/const.py:91
-msgid "the greatest"
-msgstr ""
-
-#: src/lifesim_lib/const.py:92
-msgid "the life of the party"
-msgstr ""
-
-#: src/lifesim_lib/const.py:93
-msgid "unparalled"
-msgstr ""
-
-#: src/lifesim_lib/const.py:94
-msgid "wise"
-msgstr ""
-
-#: src/lifesim_lib/const.py:95
-msgid "wonderful"
-msgstr ""
-
-#: src/lifesim_lib/const.py:96
-msgid "world-class"
-msgstr ""
-
-#: src/lifesim_lib/const.py:101
-msgid "a dimwit"
-msgstr ""
-
-#: src/lifesim_lib/const.py:102
-msgid "a dork"
-msgstr ""
-
-#: src/lifesim_lib/const.py:103
-msgid "a douchebag"
-msgstr ""
-
-#: src/lifesim_lib/const.py:104
-msgid "a dummy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:105
-msgid "a dunce"
-msgstr ""
-
-#: src/lifesim_lib/const.py:106
-msgid "a fatty"
-msgstr ""
-
-#: src/lifesim_lib/const.py:107
-msgid "a freak"
-msgstr ""
-
-#: src/lifesim_lib/const.py:108
-msgid "a goblin"
-msgstr ""
-
-#: src/lifesim_lib/const.py:109
-msgid "a jerk"
-msgstr ""
-
-#: src/lifesim_lib/const.py:110
-msgid "a jumpoff"
-msgstr ""
-
-#: src/lifesim_lib/const.py:111
-msgid "a lamebrain"
-msgstr ""
-
-#: src/lifesim_lib/const.py:112
-msgid "a loser"
-msgstr ""
-
-#: src/lifesim_lib/const.py:113
-msgid "a maniac"
-msgstr ""
-
-#: src/lifesim_lib/const.py:114
-msgid "a mouth-breather"
-msgstr ""
-
-#: src/lifesim_lib/const.py:115
-msgid "a pig"
-msgstr ""
-
-#: src/lifesim_lib/const.py:116
-msgid "a pumpkinhead"
-msgstr ""
-
-#: src/lifesim_lib/const.py:117
-msgid "a punk"
-msgstr ""
-
-#: src/lifesim_lib/const.py:118
-msgid "a scallywag"
-msgstr ""
-
-#: src/lifesim_lib/const.py:119
-msgid "a simpleton"
-msgstr ""
-
-#: src/lifesim_lib/const.py:120
-msgid "a snake"
-msgstr ""
-
-#: src/lifesim_lib/const.py:121
-msgid "a tool"
-msgstr ""
-
-#: src/lifesim_lib/const.py:122
-msgid "a tramp"
-msgstr ""
-
-#: src/lifesim_lib/const.py:123
-msgid "a triple-chin"
-msgstr ""
-
-#: src/lifesim_lib/const.py:124
-msgid "a twat"
-msgstr ""
-
-#: src/lifesim_lib/const.py:125
-msgid "a twit"
-msgstr ""
-
-#: src/lifesim_lib/const.py:126
-msgid "a villain"
-msgstr ""
-
-#: src/lifesim_lib/const.py:127
-msgid "a vulture"
-msgstr ""
-
-#: src/lifesim_lib/const.py:128
-msgid "a weasel"
-msgstr ""
-
-#: src/lifesim_lib/const.py:129
-msgid "an abomination to mankind"
-msgstr ""
-
-#: src/lifesim_lib/const.py:130
-msgid "an airhead"
-msgstr ""
-
-#: src/lifesim_lib/const.py:131
-msgid "an idiot"
-msgstr ""
-
-#: src/lifesim_lib/const.py:132
-msgid "an imbecile"
-msgstr ""
-
-#: src/lifesim_lib/const.py:133
-msgid "awful"
-msgstr ""
-
-#: src/lifesim_lib/const.py:134
-msgid "brainless"
-msgstr ""
-
-#: src/lifesim_lib/const.py:135
-msgid "careless"
-msgstr ""
-
-#: src/lifesim_lib/const.py:136
-msgid "dumb"
-msgstr ""
-
-#: src/lifesim_lib/const.py:137
-msgid "evil"
-msgstr ""
-
-#: src/lifesim_lib/const.py:138
-msgid "foolhardy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:139
-msgid "mediocre at best"
-msgstr ""
-
-#: src/lifesim_lib/const.py:140
-msgid "mentally defective"
-msgstr ""
-
-#: src/lifesim_lib/const.py:141
-msgid "nasty"
-msgstr ""
-
-#: src/lifesim_lib/const.py:142
-msgid "obtuse"
-msgstr ""
-
-#: src/lifesim_lib/const.py:143
-msgid "psycho"
-msgstr ""
-
-#: src/lifesim_lib/const.py:144
-msgid "putrid"
-msgstr ""
-
-#: src/lifesim_lib/const.py:145
-msgid "skeezy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:146
-msgid "stupid"
-msgstr ""
-
-#: src/lifesim_lib/const.py:147
-msgid "trashy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:148
-msgid "weak"
-msgstr ""
-
-#: src/lifesim_lib/const.py:149
-msgid "weaksauce"
-msgstr ""
-
-#: src/lifesim_lib/const.py:153
-msgid "died after a tree fell on the home"
-msgstr ""
-
-#: src/lifesim_lib/const.py:154
-msgid "died after falling into a well"
-msgstr ""
-
-#: src/lifesim_lib/const.py:155
-msgid "was eaten by a crocodile"
-msgstr ""
-
-#: src/lifesim_lib/const.py:156
-msgid "died after being bitten by a poisonous spider"
-msgstr ""
-
-#: src/lifesim_lib/const.py:157
-msgid "died after being struck by lightning"
-msgstr ""
-
-#: src/lifesim_lib/const.py:158
-msgid "was killed in a tornado"
-msgstr ""
-
-#: src/lifesim_lib/const.py:159
-msgid "was killed in a flood"
-msgstr ""
-
-#: src/lifesim_lib/const.py:160
-msgid "died after falling off a cliff while admiring a view"
-msgstr ""
-
-#: src/lifesim_lib/const.py:161
-msgid "died after being hit by a car while walking"
-msgstr ""
-
-#: src/lifesim_lib/const.py:162
-msgid "died after being hit by a train while walking"
-msgstr ""
-
-#: src/lifesim_lib/const.py:163
-msgid "was killed in a landslide"
-msgstr ""
-
-#: src/lifesim_lib/const.py:164
-msgid "was sucked into a jet engine and shredded to pieces"
-msgstr ""
-
-#: src/lifesim_lib/const.py:165
-msgid "died due to carbon monoxide poisoning after a car was left running in the garage"
-msgstr ""
-
-#: src/lifesim_lib/const.py:168
-msgid "died after a fireworks mishap"
-msgstr ""
-
-#: src/lifesim_lib/const.py:169
-msgid "died due to a fire in the home"
-msgstr ""
-
-#: src/lifesim_lib/const.py:170
-msgid "died after being bit on the arm by a poisonous snake"
-msgstr ""
-
-#: src/lifesim_lib/const.py:171
-msgid "died after being charged by a hippopotamus"
-msgstr ""
-
-#: src/lifesim_lib/const.py:172
-msgid "died due to smoke inhalation caused by a forest fire"
-msgstr ""
-
-#: src/lifesim_lib/const.py:173
-msgid "was killed in a fatal car crash"
-msgstr ""
-
-#: src/lifesim_lib/const.py:177 src/lifesim_lib/const.py:4658
-msgid "The Beatles"
-msgstr ""
-
-#: src/lifesim_lib/const.py:178 src/lifesim_lib/const.py:4406
-msgid "Eminem"
-msgstr ""
-
-#: src/lifesim_lib/const.py:179
-msgid "Michael Jackson"
-msgstr ""
-
-#: src/lifesim_lib/const.py:180
-msgid "Elton John"
-msgstr ""
-
-#: src/lifesim_lib/const.py:181
-msgid "Elvis Presley"
-msgstr ""
-
-#: src/lifesim_lib/const.py:182
-msgid "Rihanna"
-msgstr ""
-
-#: src/lifesim_lib/const.py:183
-msgid "Madonna"
-msgstr ""
-
-#: src/lifesim_lib/const.py:184 src/lifesim_lib/const.py:4659
-msgid "Pink Floyd"
-msgstr ""
-
-#: src/lifesim_lib/const.py:185
-msgid "Mariah Carey"
-msgstr ""
-
-#: src/lifesim_lib/const.py:186
-msgid "Taylor Swift"
-msgstr ""
-
-#: src/lifesim_lib/const.py:187
-msgid "Beyoncé"
-msgstr ""
-
-#: src/lifesim_lib/const.py:188
-msgid "Whitney Houston"
-msgstr ""
-
-#: src/lifesim_lib/const.py:189 src/lifesim_lib/const.py:4660
-msgid "The Rolling Stones"
-msgstr ""
-
-#: src/lifesim_lib/const.py:190
-msgid "Drake"
-msgstr ""
-
-#: src/lifesim_lib/const.py:191
-msgid "Justin Bieber"
-msgstr ""
-
-#: src/lifesim_lib/const.py:192
-msgid "Ed Sheeran"
-msgstr ""
-
-#: src/lifesim_lib/const.py:193
-msgid "Bruno Mars"
-msgstr ""
-
-#: src/lifesim_lib/const.py:221
-msgid "Carlton"
-msgstr ""
-
-#: src/lifesim_lib/const.py:222
-msgid "Dejo"
-msgstr ""
-
-#: src/lifesim_lib/const.py:223
-msgid "Lean"
-msgstr ""
-
-#: src/lifesim_lib/const.py:224
-msgid "Moonwalk"
-msgstr ""
-
-#: src/lifesim_lib/const.py:225
-msgid "Robot"
-msgstr ""
-
-#: src/lifesim_lib/const.py:226
-msgid "Running Man"
-msgstr ""
-
-#: src/lifesim_lib/const.py:227
-msgid "Single Ladies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:228
-msgid "Soulja Boy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:229
-msgid "Shoot"
-msgstr ""
-
-#: src/lifesim_lib/const.py:233 src/lifesim_lib/const.py:256
-msgid "an awkward"
-msgstr ""
-
-#: src/lifesim_lib/const.py:234
-msgid "a confident"
-msgstr ""
-
-#: src/lifesim_lib/const.py:235
-msgid "an enamouring"
-msgstr ""
-
-#: src/lifesim_lib/const.py:236
-msgid "a shy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:237
-msgid "a smooth"
-msgstr ""
-
-#: src/lifesim_lib/const.py:241
-msgid "at lunch"
-msgstr ""
-
-#: src/lifesim_lib/const.py:242
-msgid "by the pool"
-msgstr ""
-
-#: src/lifesim_lib/const.py:243
-msgid "by the sports fields"
-msgstr ""
-
-#: src/lifesim_lib/const.py:244
-msgid "during assembly"
-msgstr ""
-
-#: src/lifesim_lib/const.py:245
-msgid "in the gym"
-msgstr ""
-
-#: src/lifesim_lib/const.py:246
-msgid "in the library"
-msgstr ""
-
-#: src/lifesim_lib/const.py:247
-msgid "in english class"
-msgstr ""
-
-#: src/lifesim_lib/const.py:248
-msgid "in math class"
-msgstr ""
-
-#: src/lifesim_lib/const.py:249
-msgid "in science class"
-msgstr ""
-
-#: src/lifesim_lib/const.py:250
-msgid "on the way home from school"
-msgstr ""
-
-#: src/lifesim_lib/const.py:251
-msgid "on the way to school"
-msgstr ""
-
-#: src/lifesim_lib/const.py:255
-msgid "a"
-msgstr ""
-
-#: src/lifesim_lib/const.py:257
-msgid "a charmingly funny"
-msgstr ""
-
-#: src/lifesim_lib/const.py:258
-msgid "a flirtatious"
-msgstr ""
-
-#: src/lifesim_lib/const.py:271 src/lifesim_lib/const.py:1331
-#: src/lifesim_lib/const.py:1351
-msgid "Art"
-msgstr ""
-
-#: src/lifesim_lib/const.py:272
-msgid "Careers"
-msgstr ""
-
-#: src/lifesim_lib/const.py:273
-msgid "Computer Science"
-msgstr ""
-
-#: src/lifesim_lib/const.py:274 src/lifesim_lib/const.py:384
-msgid "Drama"
-msgstr ""
-
-#: src/lifesim_lib/const.py:275
-msgid "English"
-msgstr ""
-
-#: src/lifesim_lib/const.py:276 src/lifesim_lib/const.py:424
-msgid "Geography"
-msgstr ""
-
-#: src/lifesim_lib/const.py:277
-msgid "History"
-msgstr ""
-
-#: src/lifesim_lib/const.py:278
-msgid "Math"
-msgstr ""
-
-#: src/lifesim_lib/const.py:279
-msgid "Music"
-msgstr ""
-
-#: src/lifesim_lib/const.py:280
-msgid "Physical Eduacation"
-msgstr ""
-
-#: src/lifesim_lib/const.py:281
-msgid "Science"
-msgstr ""
-
-#: src/lifesim_lib/const.py:282
-msgid "Social Studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:298
-msgid "Accounting"
-msgstr ""
-
-#: src/lifesim_lib/const.py:299
-msgid "Business law"
-msgstr ""
-
-#: src/lifesim_lib/const.py:300
-msgid "Business management"
-msgstr ""
-
-#: src/lifesim_lib/const.py:301
-msgid "Consumer education"
-msgstr ""
-
-#: src/lifesim_lib/const.py:302
-msgid "Entrepreneurial skills"
-msgstr ""
-
-#: src/lifesim_lib/const.py:303
-msgid "Introduction to business"
-msgstr ""
-
-#: src/lifesim_lib/const.py:304
-msgid "Marketing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:305
-msgid "Personal finance"
-msgstr ""
-
-#: src/lifesim_lib/const.py:306
-msgid "Animation"
-msgstr ""
-
-#: src/lifesim_lib/const.py:307
-msgid "App development"
-msgstr ""
-
-#: src/lifesim_lib/const.py:308
-msgid "Audio production"
-msgstr ""
-
-#: src/lifesim_lib/const.py:309
-msgid "Computer programming"
-msgstr ""
-
-#: src/lifesim_lib/const.py:310
-msgid "Computer repair"
-msgstr ""
-
-#: src/lifesim_lib/const.py:311 src/lifesim_lib/const.py:448
-msgid "Film production"
-msgstr ""
-
-#: src/lifesim_lib/const.py:312
-msgid "Graphic design"
-msgstr ""
-
-#: src/lifesim_lib/const.py:313
-msgid "Media technology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:314
-msgid "Music production"
-msgstr ""
-
-#: src/lifesim_lib/const.py:315
-msgid "Typing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:316
-msgid "Video game development"
-msgstr ""
-
-#: src/lifesim_lib/const.py:317
-msgid "Web design"
-msgstr ""
-
-#: src/lifesim_lib/const.py:318
-msgid "Web programming"
-msgstr ""
-
-#: src/lifesim_lib/const.py:319
-msgid "Word processing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:320
-msgid "American literature"
-msgstr ""
-
-#: src/lifesim_lib/const.py:321
-msgid "British literature"
-msgstr ""
-
-#: src/lifesim_lib/const.py:322
-msgid "Contemporary literature"
-msgstr ""
-
-#: src/lifesim_lib/const.py:323
-msgid "Creative writing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:324
-msgid "Communication skills"
-msgstr ""
-
-#: src/lifesim_lib/const.py:325
-msgid "Debate"
-msgstr ""
-
-#: src/lifesim_lib/const.py:326
-msgid "English language and composition"
-msgstr ""
-
-#: src/lifesim_lib/const.py:327
-msgid "English literature and composition"
-msgstr ""
-
-#: src/lifesim_lib/const.py:328
-msgid "Humanities"
-msgstr ""
-
-#: src/lifesim_lib/const.py:329
-msgid "Journalism"
-msgstr ""
-
-#: src/lifesim_lib/const.py:330
-msgid "Literary analysis"
-msgstr ""
-
-#: src/lifesim_lib/const.py:331
-msgid "Modern literature"
-msgstr ""
-
-#: src/lifesim_lib/const.py:332
-msgid "Poetry"
-msgstr ""
-
-#: src/lifesim_lib/const.py:333
-msgid "Popular literature"
-msgstr ""
-
-#: src/lifesim_lib/const.py:334
-msgid "Rhetoric"
-msgstr ""
-
-#: src/lifesim_lib/const.py:335
-msgid "Technical writing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:336
-msgid "Works of Shakespeare"
-msgstr ""
-
-#: src/lifesim_lib/const.py:337
-msgid "World literature"
-msgstr ""
-
-#: src/lifesim_lib/const.py:338
-msgid "Written and oral communication"
-msgstr ""
-
-#: src/lifesim_lib/const.py:339
-msgid "Chemistry of foods"
-msgstr ""
-
-#: src/lifesim_lib/const.py:340
-msgid "CPR training"
-msgstr ""
-
-#: src/lifesim_lib/const.py:341
-msgid "Culinary arts"
-msgstr ""
-
-#: src/lifesim_lib/const.py:342
-msgid "Early childhood development"
-msgstr ""
-
-#: src/lifesim_lib/const.py:343
-msgid "Early childhood education"
-msgstr ""
-
-#: src/lifesim_lib/const.py:344
-msgid "Family studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:345
-msgid "Fashion and retail merchandising"
-msgstr ""
-
-#: src/lifesim_lib/const.py:346
-msgid "Fashion construction"
-msgstr ""
-
-#: src/lifesim_lib/const.py:347
-msgid "Home economics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:348
-msgid "Interior design"
-msgstr ""
-
-#: src/lifesim_lib/const.py:349
-msgid "Nutrition"
-msgstr ""
-
-#: src/lifesim_lib/const.py:350
-msgid "American Sign Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:351
-msgid "Ancient Greek Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:352
-msgid "Arabic Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:353
-msgid "Chinese Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:354
-msgid "French Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:355
-msgid "German Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:356
-msgid "Hebrew Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:357
-msgid "Italian Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:358
-msgid "Japanese Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:359
-msgid "Korean Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:360
-msgid "Latin Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:361
-msgid "Portuguese Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:362
-msgid "Russian Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:363
-msgid "Spanish Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:364
-msgid "Algebra 1"
-msgstr ""
-
-#: src/lifesim_lib/const.py:365
-msgid "Algebra 2"
-msgstr ""
-
-#: src/lifesim_lib/const.py:366
-msgid "Calculus"
-msgstr ""
-
-#: src/lifesim_lib/const.py:367
-msgid "Computer math"
-msgstr ""
-
-#: src/lifesim_lib/const.py:368
-msgid "Consumer math"
-msgstr ""
-
-#: src/lifesim_lib/const.py:369
-msgid "Fundamentals of math"
-msgstr ""
-
-#: src/lifesim_lib/const.py:370
-msgid "Geometry"
-msgstr ""
-
-#: src/lifesim_lib/const.py:371
-msgid "Integrated math"
-msgstr ""
-
-#: src/lifesim_lib/const.py:372
-msgid "Math applications"
-msgstr ""
-
-#: src/lifesim_lib/const.py:373
-msgid "Multivariable calculus"
-msgstr ""
-
-#: src/lifesim_lib/const.py:374
-msgid "Practical math"
-msgstr ""
-
-#: src/lifesim_lib/const.py:375
-msgid "Pre-algebra"
-msgstr ""
-
-#: src/lifesim_lib/const.py:376
-msgid "Pre-calculus"
-msgstr ""
-
-#: src/lifesim_lib/const.py:377
-msgid "Probability"
-msgstr ""
-
-#: src/lifesim_lib/const.py:378
-msgid "Quantitative literacy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:379
-msgid "Statistics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:380
-msgid "Trigonometry"
-msgstr ""
-
-#: src/lifesim_lib/const.py:381
-msgid "Choir"
-msgstr ""
-
-#: src/lifesim_lib/const.py:382
-msgid "Concert band"
-msgstr ""
-
-#: src/lifesim_lib/const.py:383 src/lifesim_lib/const.py:395
-msgid "Dance"
-msgstr ""
-
-#: src/lifesim_lib/const.py:385
-msgid "Guitar"
-msgstr ""
-
-#: src/lifesim_lib/const.py:386
-msgid "Jazz band"
-msgstr ""
-
-#: src/lifesim_lib/const.py:387
-msgid "Marching band"
-msgstr ""
-
-#: src/lifesim_lib/const.py:388
-msgid "Music theory"
-msgstr ""
-
-#: src/lifesim_lib/const.py:389
-msgid "Orchestra"
-msgstr ""
-
-#: src/lifesim_lib/const.py:390
-msgid "Percussion"
-msgstr ""
-
-#: src/lifesim_lib/const.py:391
-msgid "Piano"
-msgstr ""
-
-#: src/lifesim_lib/const.py:392
-msgid "Theater technology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:393 src/lifesim_lib/const.py:2216
-msgid "World music"
-msgstr ""
-
-#: src/lifesim_lib/const.py:394
-msgid "Aerobics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:396
-msgid "Gymnastics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:397 src/menus/main.py:553
-#: src/people/classes/player.py:691
-msgid "Health"
-msgstr ""
-
-#: src/lifesim_lib/const.py:398
-msgid "Lifeguard training"
-msgstr ""
-
-#: src/lifesim_lib/const.py:399
-msgid "Pilates"
-msgstr ""
-
-#: src/lifesim_lib/const.py:400
-msgid "Racket sports"
-msgstr ""
-
-#: src/lifesim_lib/const.py:401
-msgid "Specialized sports"
-msgstr ""
-
-#: src/lifesim_lib/const.py:402
-msgid "Swimming"
-msgstr ""
-
-#: src/lifesim_lib/const.py:403
-msgid "Weight training"
-msgstr ""
-
-#: src/lifesim_lib/const.py:404
-msgid "Yoga"
-msgstr ""
-
-#: src/lifesim_lib/const.py:405
-msgid "Agriculture"
-msgstr ""
-
-#: src/lifesim_lib/const.py:406
-msgid "Astronomy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:407
-msgid "Biology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:408
-msgid "Botany"
-msgstr ""
-
-#: src/lifesim_lib/const.py:409
-msgid "Chemistry"
-msgstr ""
-
-#: src/lifesim_lib/const.py:410
-msgid "Earth science"
-msgstr ""
-
-#: src/lifesim_lib/const.py:411 src/lifesim_lib/const.py:461
-msgid "Electronics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:412
-msgid "Environmental science"
-msgstr ""
-
-#: src/lifesim_lib/const.py:413
-msgid "Environmental studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:414
-msgid "Forensic science"
-msgstr ""
-
-#: src/lifesim_lib/const.py:415
-msgid "Geology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:416
-msgid "Marine biology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:417
-msgid "Oceanography"
-msgstr ""
-
-#: src/lifesim_lib/const.py:418
-msgid "Physical science"
-msgstr ""
-
-#: src/lifesim_lib/const.py:419
-msgid "Physics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:420
-msgid "Zoology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:421
-msgid "Cultural anthropology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:422
-msgid "Current events"
-msgstr ""
-
-#: src/lifesim_lib/const.py:423
-msgid "European history"
-msgstr ""
-
-#: src/lifesim_lib/const.py:425
-msgid "Global studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:426
-msgid "Human geography"
-msgstr ""
-
-#: src/lifesim_lib/const.py:427
-msgid "International relations"
-msgstr ""
-
-#: src/lifesim_lib/const.py:428
-msgid "Law"
-msgstr ""
-
-#: src/lifesim_lib/const.py:429
-msgid "Macroeconomics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:430
-msgid "Microeconomics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:431
-msgid "Modern world studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:432
-msgid "Physical anthropology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:433
-msgid "Political studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:434
-msgid "Psychology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:435
-msgid "Religious studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:436
-msgid "Sociology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:437
-msgid "National government"
-msgstr ""
-
-#: src/lifesim_lib/const.py:438
-msgid "National history"
-msgstr ""
-
-#: src/lifesim_lib/const.py:439
-msgid "Women's studies"
-msgstr ""
-
-#: src/lifesim_lib/const.py:440
-msgid "World history"
-msgstr ""
-
-#: src/lifesim_lib/const.py:441
-msgid "World politics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:442
-msgid "World religions"
-msgstr ""
-
-#: src/lifesim_lib/const.py:443
-msgid "3-D art"
-msgstr ""
-
-#: src/lifesim_lib/const.py:444
-msgid "Art history"
-msgstr ""
-
-#: src/lifesim_lib/const.py:445
-msgid "Ceramics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:446
-msgid "Digital media"
-msgstr ""
-
-#: src/lifesim_lib/const.py:447
-msgid "Drawing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:449
-msgid "Jewelry design"
-msgstr ""
-
-#: src/lifesim_lib/const.py:450
-msgid "Painting"
-msgstr ""
-
-#: src/lifesim_lib/const.py:451
-msgid "Photography"
-msgstr ""
-
-#: src/lifesim_lib/const.py:452
-msgid "Printmaking"
-msgstr ""
-
-#: src/lifesim_lib/const.py:453
-msgid "Sculpture"
-msgstr ""
-
-#: src/lifesim_lib/const.py:454
-msgid "Auto body repair"
-msgstr ""
-
-#: src/lifesim_lib/const.py:455
-msgid "Auto mechanics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:456
-msgid "Building construction"
-msgstr ""
-
-#: src/lifesim_lib/const.py:457
-msgid "Computer-aided drafting"
-msgstr ""
-
-#: src/lifesim_lib/const.py:458
-msgid "Cosmetology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:459
-msgid "Criminal justice"
-msgstr ""
-
-#: src/lifesim_lib/const.py:460
-msgid "Driver education"
-msgstr ""
-
-#: src/lifesim_lib/const.py:462
-msgid "FFA (Future Farmers of America)"
-msgstr ""
-
-#: src/lifesim_lib/const.py:463
-msgid "Fire science"
-msgstr ""
-
-#: src/lifesim_lib/const.py:464
-msgid "Heating and cooling systems"
-msgstr ""
-
-#: src/lifesim_lib/const.py:465
-msgid "Hospitality and tourism"
-msgstr ""
-
-#: src/lifesim_lib/const.py:466
-msgid "JROTC (Junior Reserve Officers' Training Corps)"
-msgstr ""
-
-#: src/lifesim_lib/const.py:467
-msgid "Metalworking"
-msgstr ""
-
-#: src/lifesim_lib/const.py:468
-msgid "Networking"
-msgstr ""
-
-#: src/lifesim_lib/const.py:469
-msgid "Plumbing"
-msgstr ""
-
-#: src/lifesim_lib/const.py:470
-msgid "Production technology"
-msgstr ""
-
-#: src/lifesim_lib/const.py:471
-msgid "Refrigeration fundamentals"
-msgstr ""
-
-#: src/lifesim_lib/const.py:472 src/lifesim_lib/const.py:1269
-msgid "Robotics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:473
-msgid "Woodworking"
-msgstr ""
-
-#: src/lifesim_lib/const.py:477
-msgid "Ooh La La!"
-msgstr ""
-
-#: src/lifesim_lib/const.py:478
-msgid "Why, hello there!"
-msgstr ""
-
-#: src/lifesim_lib/const.py:499
-msgid "You have a hard time walking straight the next day"
-msgstr ""
-
-#: src/lifesim_lib/const.py:500 src/lifesim_lib/const.py:507
-msgid "You left your underwear behind"
-msgstr ""
-
-#: src/lifesim_lib/const.py:503 src/lifesim_lib/const.py:510
-#: src/lifesim_lib/const.py:545 src/lifesim_lib/const.py:663
-#: src/lifesim_lib/const.py:719 src/lifesim_lib/const.py:734
-#: src/lifesim_lib/const.py:752 src/lifesim_lib/const.py:756
-#: src/lifesim_lib/const.py:764 src/lifesim_lib/const.py:768
-#: src/lifesim_lib/const.py:772 src/lifesim_lib/const.py:777
-#: src/lifesim_lib/const.py:782 src/lifesim_lib/const.py:786
-#: src/lifesim_lib/const.py:814 src/lifesim_lib/const.py:825
-#: src/lifesim_lib/const.py:841 src/lifesim_lib/const.py:850
-#: src/lifesim_lib/const.py:854 src/lifesim_lib/const.py:858
-#: src/lifesim_lib/const.py:862 src/lifesim_lib/const.py:866
-#: src/lifesim_lib/const.py:870 src/lifesim_lib/const.py:878
-#: src/lifesim_lib/const.py:882 src/lifesim_lib/const.py:926
-#: src/lifesim_lib/const.py:930 src/lifesim_lib/const.py:934
-#: src/lifesim_lib/const.py:946 src/lifesim_lib/const.py:963
-#: src/lifesim_lib/const.py:964 src/lifesim_lib/const.py:968
-#: src/lifesim_lib/const.py:969 src/lifesim_lib/const.py:974
-#: src/lifesim_lib/const.py:980 src/lifesim_lib/const.py:986
-#: src/lifesim_lib/const.py:1016 src/lifesim_lib/const.py:1020
-#: src/lifesim_lib/const.py:1025 src/lifesim_lib/const.py:1029
-#: src/lifesim_lib/const.py:1237 src/lifesim_lib/const.py:2237
-#: src/lifesim_lib/const.py:2368 src/lifesim_lib/const.py:2926
-#: src/lifesim_lib/const.py:3421 src/lifesim_lib/const.py:3424
-#: src/lifesim_lib/const.py:3427 src/lifesim_lib/const.py:3430
-#: src/lifesim_lib/const.py:3433 src/lifesim_lib/const.py:3436
-#: src/lifesim_lib/const.py:3658 src/lifesim_lib/const.py:3670
-#: src/lifesim_lib/const.py:3804 src/lifesim_lib/const.py:3807
-#: src/lifesim_lib/const.py:3814 src/lifesim_lib/const.py:3819
-#: src/lifesim_lib/const.py:4852 src/lifesim_lib/const.py:4853
-#: src/lifesim_lib/const.py:4867 src/lifesim_lib/const.py:5064
-msgid ""
-msgstr ""
-
-#: src/lifesim_lib/const.py:520
-msgid "A :dude"
-msgstr ""
-
-#: src/lifesim_lib/const.py:521
-msgid "A guy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:522
-msgid "An interesting guy"
-msgstr ""
-
-#: src/lifesim_lib/const.py:525
-msgid "invites you to exchange nude pics"
-msgstr ""
-
-#: src/lifesim_lib/const.py:535
-msgid "got up and left"
-msgstr ""
-
-#: src/lifesim_lib/const.py:548 src/lifesim_lib/const.py:573
-#: src/lifesim_lib/const.py:598 src/lifesim_lib/const.py:1120
-msgid "Principal"
-msgstr ""
-
-#: src/lifesim_lib/const.py:549 src/lifesim_lib/const.py:574
-#: src/lifesim_lib/const.py:599 src/lifesim_lib/const.py:942
-#: src/lifesim_lib/const.py:1119
-msgid "Assistant Principal"
-msgstr ""
-
-#: src/lifesim_lib/const.py:550 src/lifesim_lib/const.py:575
-#: src/lifesim_lib/const.py:600
-msgid "Administrator"
-msgstr ""
-
-#: src/lifesim_lib/const.py:551 src/lifesim_lib/const.py:576
-#: src/lifesim_lib/const.py:601
-msgid "Cleaner"
-msgstr ""
-
-#: src/lifesim_lib/const.py:552 src/lifesim_lib/const.py:577
-#: src/lifesim_lib/const.py:603
-msgid "Executive Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:553 src/lifesim_lib/const.py:578
-#: src/lifesim_lib/const.py:604 src/lifesim_lib/const.py:616
-#: src/lifesim_lib/const.py:626
-msgid "Food Service"
-msgstr ""
-
-#: src/lifesim_lib/const.py:554 src/lifesim_lib/const.py:579
-#: src/lifesim_lib/const.py:605 src/lifesim_lib/const.py:617
-#: src/lifesim_lib/const.py:627
-msgid "Groundskeeper"
-msgstr ""
-
-#: src/lifesim_lib/const.py:555 src/lifesim_lib/const.py:580
-#: src/lifesim_lib/const.py:606
-msgid "Substitute Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:559 src/lifesim_lib/const.py:585
-msgid "Art Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:560
-msgid "Careers Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:561
-msgid "IT Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:562 src/lifesim_lib/const.py:588
-msgid "Drama Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:563 src/lifesim_lib/const.py:590
-msgid "English Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:564
-msgid "Geography Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:565
-msgid "History Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:566 src/lifesim_lib/const.py:592
-msgid "Math Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:567 src/lifesim_lib/const.py:593
-msgid "Music Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:568 src/lifesim_lib/const.py:594
-msgid "P.E. Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:569
-msgid "Science Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:570
-msgid "Social Studies Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:584
-msgid "Accounting Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:586
-msgid "Chemistry Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:587
-msgid "Computer Science Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:589
-msgid "Economics Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:591
-msgid "Foreign Language"
-msgstr ""
-
-#: src/lifesim_lib/const.py:595
-msgid "Physics Teacher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:602
-msgid "Careers Counsellor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:610 src/lifesim_lib/const.py:620
-msgid "Associate Professor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:611 src/lifesim_lib/const.py:620
-#: src/lifesim_lib/const.py:1024 src/lifesim_lib/const.py:1048
-#: src/lifesim_lib/const.py:1116
-msgid "Professor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:612 src/lifesim_lib/const.py:620
-msgid "Researcher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:615 src/lifesim_lib/const.py:622
-msgid "Dean"
-msgstr ""
-
-#: src/lifesim_lib/const.py:623
-msgid "Associate Dean"
-msgstr ""
-
-#: src/lifesim_lib/const.py:624
-msgid "Chancellor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:625
-msgid "Director of Education"
-msgstr ""
-
-#: src/lifesim_lib/const.py:628
-msgid "Librarian"
-msgstr ""
-
-#: src/lifesim_lib/const.py:629 src/lifesim_lib/const.py:1636
-msgid "President"
-msgstr ""
-
-#: src/lifesim_lib/const.py:630
-msgid "Vice Chancellor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:631
-msgid "Vice President"
-msgstr ""
-
-#: src/lifesim_lib/const.py:637
-msgid "High School Dropout"
-msgstr ""
-
-#: src/lifesim_lib/const.py:638
-msgid "High School Student"
-msgstr ""
-
-#: src/lifesim_lib/const.py:639
-msgid "High School Student, Part-time Arcade Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:640
-msgid "High School Student, Part-time Armpit Sniffer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:641
-msgid "High School Student, Part-time Barista"
-msgstr ""
-
-#: src/lifesim_lib/const.py:642
-msgid "High School Student, Part-time Bike Shop Mechanic"
-msgstr ""
-
-#: src/lifesim_lib/const.py:643
-msgid "High School Student, Part-time Boutique Associate"
-msgstr ""
-
-#: src/lifesim_lib/const.py:644
-msgid "High School Student, Part-time Bowling Alley Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:645
-msgid "High School Student, Part-time Camp Counsellor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:646
-msgid "High School Student, Part-time Car Wash Attendant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:647
-msgid "High School Student, Part-time Dance Instructor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:648
-msgid "High School Student, Part-time Doorman"
-msgstr ""
-
-#: src/lifesim_lib/const.py:649
-msgid "High School Student, Part-time Fitness Instructor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:650
-msgid "High School Student, Part-time Gym Receptionist"
-msgstr ""
-
-#: src/lifesim_lib/const.py:651
-msgid "High School Student, Part-time Hotel Concierge"
-msgstr ""
-
-#: src/lifesim_lib/const.py:652
-msgid "High School Student, Part-time Ice Cream Scooper"
-msgstr ""
-
-#: src/lifesim_lib/const.py:653
-msgid "High School Student, Part-time Lifeguard"
-msgstr ""
-
-#: src/lifesim_lib/const.py:654
-msgid "High School Student, Part-time Mall Kiosk Worker"
-msgstr ""
-
-#: src/lifesim_lib/const.py:655
-msgid "High School Student, Part-time Personal Trainer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:656
-msgid "High School Student, Part-time Usher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:657
-msgid "High School Student, Part-time Valet"
-msgstr ""
-
-#: src/lifesim_lib/const.py:658
-msgid "High School Student, Part-time Window Cleaner"
-msgstr ""
-
-#: src/lifesim_lib/const.py:662
-msgid "Unemployed"
-msgstr ""
-
-#: src/lifesim_lib/const.py:668
-msgid "Handyman"
-msgstr ""
-
-#: src/lifesim_lib/const.py:669
-msgid "Tutor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:670
-msgid "Caretaker"
-msgstr ""
-
-#: src/lifesim_lib/const.py:671
-msgid "Lawn Mower"
-msgstr ""
-
-#: src/lifesim_lib/const.py:672
-msgid "Babysitter"
-msgstr ""
-
-#: src/lifesim_lib/const.py:673
-msgid "Dog Walker"
-msgstr ""
-
-#: src/lifesim_lib/const.py:674
-msgid "Pet Sitter"
-msgstr ""
-
-#: src/lifesim_lib/const.py:675
-msgid "Lemonade Stand"
-msgstr ""
-
-#: src/lifesim_lib/const.py:676
-msgid "Kissing booth"
-msgstr ""
-
-#: src/lifesim_lib/const.py:679 src/lifesim_lib/const.py:728
-msgid "Arcade Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:680
-msgid "Armpit Sniffer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:681
-msgid "Barista"
-msgstr ""
-
-#: src/lifesim_lib/const.py:682
-msgid "Bellhop"
-msgstr ""
-
-#: src/lifesim_lib/const.py:683
-msgid "Bike Shop Mechanic"
-msgstr ""
-
-#: src/lifesim_lib/const.py:684
-msgid "Bookkeeper"
-msgstr ""
-
-#: src/lifesim_lib/const.py:685
-msgid "Boutique Associate"
-msgstr ""
-
-#: src/lifesim_lib/const.py:686
-msgid "Bowling Alley Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:687
-msgid "Camp Counsellor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:688 src/lifesim_lib/const.py:718
-msgid "Car Wash Attendant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:689
-msgid "Caterer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:690
-msgid "Collections Specialist"
-msgstr ""
-
-#: src/lifesim_lib/const.py:691 src/lifesim_lib/const.py:731
-msgid "Concessions Attendant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:692
-msgid "Dance Instructor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:693
-msgid "Delivery Driver"
-msgstr ""
-
-#: src/lifesim_lib/const.py:694
-msgid "Doorman"
-msgstr ""
-
-#: src/lifesim_lib/const.py:695
-msgid "Fitness Instructor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:696
-msgid "Gym Receptionist"
-msgstr ""
-
-#: src/lifesim_lib/const.py:697
-msgid "Hotel Concierge"
-msgstr ""
-
-#: src/lifesim_lib/const.py:698
-msgid "Hotel Front Desk Clerk"
-msgstr ""
-
-#: src/lifesim_lib/const.py:699
-msgid "Ice Cream Scooper"
-msgstr ""
-
-#: src/lifesim_lib/const.py:700
-msgid "Lifeguard"
-msgstr ""
-
-#: src/lifesim_lib/const.py:701
-msgid "Mall Kiosk Worker"
-msgstr ""
-
-#: src/lifesim_lib/const.py:702
-msgid "Mall Santa"
-msgstr ""
-
-#: src/lifesim_lib/const.py:703
-msgid "Office Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:704
-msgid "Personal Trainer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:705 src/lifesim_lib/const.py:725
-msgid "Pool Towel Attendant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:706
-msgid "Sandwich Maker"
-msgstr ""
-
-#: src/lifesim_lib/const.py:707
-msgid "School Bus Driver"
-msgstr ""
-
-#: src/lifesim_lib/const.py:708
-msgid "Sign Holder"
-msgstr ""
-
-#: src/lifesim_lib/const.py:709 src/lifesim_lib/const.py:735
-msgid "Street Sweeper"
-msgstr ""
-
-#: src/lifesim_lib/const.py:710
-msgid "Swim Instructor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:711
-msgid "Usher"
-msgstr ""
-
-#: src/lifesim_lib/const.py:712
-msgid "Valet"
-msgstr ""
-
-#: src/lifesim_lib/const.py:713
-msgid "Window Cleaner"
-msgstr ""
-
-#: src/lifesim_lib/const.py:714 src/lifesim_lib/const.py:722
-msgid "Yoga Receptionist"
-msgstr ""
-
-#: src/lifesim_lib/const.py:743
-msgid "Fluffer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:744 src/lifesim_lib/const.py:1064
-msgid "Porn Actor"
-msgstr ""
-
-#: src/lifesim_lib/const.py:745 src/lifesim_lib/const.py:1065
-msgid "Porn Cameraman"
-msgstr ""
-
-#: src/lifesim_lib/const.py:746 src/lifesim_lib/const.py:1066
-msgid "Porn Star"
-msgstr ""
-
-#: src/lifesim_lib/const.py:747 src/lifesim_lib/const.py:1067
-msgid "Porn Writer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:748 src/lifesim_lib/const.py:1068
-msgid "Porn Director"
-msgstr ""
-
-#: src/lifesim_lib/const.py:751
-msgid "Junior App Developer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:755
-msgid "App Developer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:759 src/lifesim_lib/const.py:763
-msgid "Baggage Handler"
-msgstr ""
-
-#: src/lifesim_lib/const.py:760
-msgid "Junior Flight Attendant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:767
-msgid "Junior Architect"
-msgstr ""
-
-#: src/lifesim_lib/const.py:771
-msgid "Architect"
-msgstr ""
-
-#: src/lifesim_lib/const.py:775
-msgid "Apprentice Auto Mechanic"
-msgstr ""
-
-#: src/lifesim_lib/const.py:776
-msgid "Apprentice Auto Electrician"
-msgstr ""
-
-#: src/lifesim_lib/const.py:780
-msgid "Auto Mechanic"
-msgstr ""
-
-#: src/lifesim_lib/const.py:781
-msgid "Auto Electrician"
-msgstr ""
-
-#: src/lifesim_lib/const.py:785
-msgid "Deacon"
-msgstr ""
-
-#: src/lifesim_lib/const.py:789
-msgid "Acrobat"
-msgstr ""
-
-#: src/lifesim_lib/const.py:790
-msgid "Clown"
-msgstr ""
-
-#: src/lifesim_lib/const.py:791 src/lifesim_lib/const.py:849
-msgid "Dancer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:792
-msgid "Fire Breather"
-msgstr ""
-
-#: src/lifesim_lib/const.py:793
-msgid "Fire Eater"
-msgstr ""
-
-#: src/lifesim_lib/const.py:794
-msgid "Horse Rider"
-msgstr ""
-
-#: src/lifesim_lib/const.py:795
-msgid "Juggler"
-msgstr ""
-
-#: src/lifesim_lib/const.py:796
-msgid "Lion Tamer"
-msgstr ""
-
-#: src/lifesim_lib/const.py:797
-msgid "Magician"
-msgstr ""
-
-#: src/lifesim_lib/const.py:798
-msgid "Magician's Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:799
-msgid "Plate Spinner"
-msgstr ""
-
-#: src/lifesim_lib/const.py:800
-msgid "Sword Eater"
-msgstr ""
-
-#: src/lifesim_lib/const.py:801
-msgid "Tightrope Walker"
-msgstr ""
-
-#: src/lifesim_lib/const.py:802
-msgid "Trapeze Artist"
-msgstr ""
-
-#: src/lifesim_lib/const.py:803
-msgid "Unicyclist"
-msgstr ""
-
-#: src/lifesim_lib/const.py:806 src/lifesim_lib/const.py:817
-msgid "Administrative Assistant"
-msgstr ""
-
-#: src/lifesim_lib/const.py:807 src/lifesim_lib/const.py:819
+#: src/lifesim_lib/const.py:27 src/lifesim_lib/const.py:816
+#: src/lifesim_lib/const.py:828
 msgid "Janitor"
 msgstr ""
 
+#: src/lifesim_lib/const.py:28
+msgid "Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:29
+msgid "Software Developer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:33
+msgid "Depression"
+msgstr ""
+
+#: src/lifesim_lib/const.py:34
+msgid "High Blood Pressure"
+msgstr ""
+
+#: src/lifesim_lib/const.py:38
+msgid "a boss"
+msgstr ""
+
+#: src/lifesim_lib/const.py:39
+msgid "a bubbly personality"
+msgstr ""
+
+#: src/lifesim_lib/const.py:40
+msgid "a brilliant mind"
+msgstr ""
+
+#: src/lifesim_lib/const.py:41
+msgid "a champion"
+msgstr ""
+
+#: src/lifesim_lib/const.py:42
+msgid "a gem"
+msgstr ""
+
+#: src/lifesim_lib/const.py:43
+msgid "a genius"
+msgstr ""
+
+#: src/lifesim_lib/const.py:44
+msgid "a jewel"
+msgstr ""
+
+#: src/lifesim_lib/const.py:45
+msgid "a legend"
+msgstr ""
+
+#: src/lifesim_lib/const.py:46
+msgid "a player"
+msgstr ""
+
+#: src/lifesim_lib/const.py:47
+msgid "a revolutionary"
+msgstr ""
+
+#: src/lifesim_lib/const.py:48
+msgid "a smart cookie"
+msgstr ""
+
+#: src/lifesim_lib/const.py:49
+msgid "a treasure"
+msgstr ""
+
+#: src/lifesim_lib/const.py:50
+msgid "a winner"
+msgstr ""
+
+#: src/lifesim_lib/const.py:51
+msgid "a wizard"
+msgstr ""
+
+#: src/lifesim_lib/const.py:52
+msgid "a VIP"
+msgstr ""
+
+#: src/lifesim_lib/const.py:53
+msgid "a visionary"
+msgstr ""
+
+#: src/lifesim_lib/const.py:54
+msgid "adorable"
+msgstr ""
+
+#: src/lifesim_lib/const.py:55
+msgid "admirable"
+msgstr ""
+
+#: src/lifesim_lib/const.py:56
+msgid "an OG"
+msgstr ""
+
+#: src/lifesim_lib/const.py:57
+msgid "an eager beaver"
+msgstr ""
+
+#: src/lifesim_lib/const.py:58
+msgid "brave"
+msgstr ""
+
+#: src/lifesim_lib/const.py:59
+msgid "bright"
+msgstr ""
+
+#: src/lifesim_lib/const.py:60
+msgid "brilliant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:61
+msgid "charming"
+msgstr ""
+
+#: src/lifesim_lib/const.py:62
+msgid "clever"
+msgstr ""
+
+#: src/lifesim_lib/const.py:63
+msgid "cool"
+msgstr ""
+
+#: src/lifesim_lib/const.py:64
+msgid "courageous"
+msgstr ""
+
+#: src/lifesim_lib/const.py:65
+msgid "cute"
+msgstr ""
+
+#: src/lifesim_lib/const.py:66
+msgid "dashing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:67
+msgid "delightful"
+msgstr ""
+
+#: src/lifesim_lib/const.py:68
+msgid "dope"
+msgstr ""
+
+#: src/lifesim_lib/const.py:69
+msgid "elite"
+msgstr ""
+
+#: src/lifesim_lib/const.py:70
+msgid "fascinating"
+msgstr ""
+
+#: src/lifesim_lib/const.py:71
+msgid "fearless"
+msgstr ""
+
+#: src/lifesim_lib/const.py:72
+msgid "fine"
+msgstr ""
+
+#: src/lifesim_lib/const.py:73
+msgid "fresh"
+msgstr ""
+
+#: src/lifesim_lib/const.py:74
+msgid "gorgeous"
+msgstr ""
+
+#: src/lifesim_lib/const.py:75
+msgid "golden"
+msgstr ""
+
+#: src/lifesim_lib/const.py:76
+msgid "groovy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:77
+msgid "inspiring"
+msgstr ""
+
+#: src/lifesim_lib/const.py:78
+msgid "intelligent"
+msgstr ""
+
+#: src/lifesim_lib/const.py:79
+msgid "legendary"
+msgstr ""
+
+#: src/lifesim_lib/const.py:80
+msgid "lionhearted"
+msgstr ""
+
+#: src/lifesim_lib/const.py:81
+msgid "magnetic"
+msgstr ""
+
+#: src/lifesim_lib/const.py:82
+msgid "magnificent"
+msgstr ""
+
+#: src/lifesim_lib/const.py:83
+msgid "motivating"
+msgstr ""
+
+#: src/lifesim_lib/const.py:84
+msgid "neat"
+msgstr ""
+
+#: src/lifesim_lib/const.py:85
+msgid "nifty"
+msgstr ""
+
+#: src/lifesim_lib/const.py:86
+msgid "one-of-a-kind"
+msgstr ""
+
+#: src/lifesim_lib/const.py:87
+msgid "a perfect 10"
+msgstr ""
+
+#: src/lifesim_lib/const.py:88
+msgid "phenomenal"
+msgstr ""
+
+#: src/lifesim_lib/const.py:89
+msgid "rad"
+msgstr ""
+
+#: src/lifesim_lib/const.py:90
+msgid "savage"
+msgstr ""
+
+#: src/lifesim_lib/const.py:91
+msgid "smart"
+msgstr ""
+
+#: src/lifesim_lib/const.py:92
+msgid "spectatular"
+msgstr ""
+
+#: src/lifesim_lib/const.py:93
+msgid "stellar"
+msgstr ""
+
+#: src/lifesim_lib/const.py:94
+msgid "strong"
+msgstr ""
+
+#: src/lifesim_lib/const.py:95
+msgid "stunning"
+msgstr ""
+
+#: src/lifesim_lib/const.py:96
+msgid "stylish"
+msgstr ""
+
+#: src/lifesim_lib/const.py:97
+msgid "swell"
+msgstr ""
+
+#: src/lifesim_lib/const.py:98
+msgid "the best"
+msgstr ""
+
+#: src/lifesim_lib/const.py:99
+msgid "the GOAT"
+msgstr ""
+
+#: src/lifesim_lib/const.py:100
+msgid "the greatest"
+msgstr ""
+
+#: src/lifesim_lib/const.py:101
+msgid "the life of the party"
+msgstr ""
+
+#: src/lifesim_lib/const.py:102
+msgid "unparalled"
+msgstr ""
+
+#: src/lifesim_lib/const.py:103
+msgid "wise"
+msgstr ""
+
+#: src/lifesim_lib/const.py:104
+msgid "wonderful"
+msgstr ""
+
+#: src/lifesim_lib/const.py:105
+msgid "world-class"
+msgstr ""
+
+#: src/lifesim_lib/const.py:110
+msgid "a dimwit"
+msgstr ""
+
+#: src/lifesim_lib/const.py:111
+msgid "a dork"
+msgstr ""
+
+#: src/lifesim_lib/const.py:112
+msgid "a douchebag"
+msgstr ""
+
+#: src/lifesim_lib/const.py:113
+msgid "a dummy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:114
+msgid "a dunce"
+msgstr ""
+
+#: src/lifesim_lib/const.py:115
+msgid "a fatty"
+msgstr ""
+
+#: src/lifesim_lib/const.py:116
+msgid "a freak"
+msgstr ""
+
+#: src/lifesim_lib/const.py:117
+msgid "a goblin"
+msgstr ""
+
+#: src/lifesim_lib/const.py:118
+msgid "a jerk"
+msgstr ""
+
+#: src/lifesim_lib/const.py:119
+msgid "a jumpoff"
+msgstr ""
+
+#: src/lifesim_lib/const.py:120
+msgid "a lamebrain"
+msgstr ""
+
+#: src/lifesim_lib/const.py:121
+msgid "a loser"
+msgstr ""
+
+#: src/lifesim_lib/const.py:122
+msgid "a maniac"
+msgstr ""
+
+#: src/lifesim_lib/const.py:123
+msgid "a mouth-breather"
+msgstr ""
+
+#: src/lifesim_lib/const.py:124
+msgid "a pig"
+msgstr ""
+
+#: src/lifesim_lib/const.py:125
+msgid "a pumpkinhead"
+msgstr ""
+
+#: src/lifesim_lib/const.py:126
+msgid "a punk"
+msgstr ""
+
+#: src/lifesim_lib/const.py:127
+msgid "a scallywag"
+msgstr ""
+
+#: src/lifesim_lib/const.py:128
+msgid "a simpleton"
+msgstr ""
+
+#: src/lifesim_lib/const.py:129
+msgid "a snake"
+msgstr ""
+
+#: src/lifesim_lib/const.py:130
+msgid "a tool"
+msgstr ""
+
+#: src/lifesim_lib/const.py:131
+msgid "a tramp"
+msgstr ""
+
+#: src/lifesim_lib/const.py:132
+msgid "a triple-chin"
+msgstr ""
+
+#: src/lifesim_lib/const.py:133
+msgid "a twat"
+msgstr ""
+
+#: src/lifesim_lib/const.py:134
+msgid "a twit"
+msgstr ""
+
+#: src/lifesim_lib/const.py:135
+msgid "a villain"
+msgstr ""
+
+#: src/lifesim_lib/const.py:136
+msgid "a vulture"
+msgstr ""
+
+#: src/lifesim_lib/const.py:137
+msgid "a weasel"
+msgstr ""
+
+#: src/lifesim_lib/const.py:138
+msgid "an abomination to mankind"
+msgstr ""
+
+#: src/lifesim_lib/const.py:139
+msgid "an airhead"
+msgstr ""
+
+#: src/lifesim_lib/const.py:140
+msgid "an idiot"
+msgstr ""
+
+#: src/lifesim_lib/const.py:141
+msgid "an imbecile"
+msgstr ""
+
+#: src/lifesim_lib/const.py:142
+msgid "awful"
+msgstr ""
+
+#: src/lifesim_lib/const.py:143
+msgid "brainless"
+msgstr ""
+
+#: src/lifesim_lib/const.py:144
+msgid "careless"
+msgstr ""
+
+#: src/lifesim_lib/const.py:145
+msgid "dumb"
+msgstr ""
+
+#: src/lifesim_lib/const.py:146
+msgid "evil"
+msgstr ""
+
+#: src/lifesim_lib/const.py:147
+msgid "foolhardy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:148
+msgid "mediocre at best"
+msgstr ""
+
+#: src/lifesim_lib/const.py:149
+msgid "mentally defective"
+msgstr ""
+
+#: src/lifesim_lib/const.py:150
+msgid "nasty"
+msgstr ""
+
+#: src/lifesim_lib/const.py:151
+msgid "obtuse"
+msgstr ""
+
+#: src/lifesim_lib/const.py:152
+msgid "psycho"
+msgstr ""
+
+#: src/lifesim_lib/const.py:153
+msgid "putrid"
+msgstr ""
+
+#: src/lifesim_lib/const.py:154
+msgid "skeezy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:155
+msgid "stupid"
+msgstr ""
+
+#: src/lifesim_lib/const.py:156
+msgid "trashy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:157
+msgid "weak"
+msgstr ""
+
+#: src/lifesim_lib/const.py:158
+msgid "weaksauce"
+msgstr ""
+
+#: src/lifesim_lib/const.py:162
+msgid "died after a tree fell on the home"
+msgstr ""
+
+#: src/lifesim_lib/const.py:163
+msgid "died after falling into a well"
+msgstr ""
+
+#: src/lifesim_lib/const.py:164
+msgid "was eaten by a crocodile"
+msgstr ""
+
+#: src/lifesim_lib/const.py:165
+msgid "died after being bitten by a poisonous spider"
+msgstr ""
+
+#: src/lifesim_lib/const.py:166
+msgid "died after being struck by lightning"
+msgstr ""
+
+#: src/lifesim_lib/const.py:167
+msgid "was killed in a tornado"
+msgstr ""
+
+#: src/lifesim_lib/const.py:168
+msgid "was killed in a flood"
+msgstr ""
+
+#: src/lifesim_lib/const.py:169
+msgid "died after falling off a cliff while admiring a view"
+msgstr ""
+
+#: src/lifesim_lib/const.py:170
+msgid "died after being hit by a car while walking"
+msgstr ""
+
+#: src/lifesim_lib/const.py:171
+msgid "died after being hit by a train while walking"
+msgstr ""
+
+#: src/lifesim_lib/const.py:172
+msgid "was killed in a landslide"
+msgstr ""
+
+#: src/lifesim_lib/const.py:173
+msgid "was sucked into a jet engine and shredded to pieces"
+msgstr ""
+
+#: src/lifesim_lib/const.py:174
+msgid "died due to carbon monoxide poisoning after a car was left running in the garage"
+msgstr ""
+
+#: src/lifesim_lib/const.py:177
+msgid "died after a fireworks mishap"
+msgstr ""
+
+#: src/lifesim_lib/const.py:178
+msgid "died due to a fire in the home"
+msgstr ""
+
+#: src/lifesim_lib/const.py:179
+msgid "died after being bit on the arm by a poisonous snake"
+msgstr ""
+
+#: src/lifesim_lib/const.py:180
+msgid "died after being charged by a hippopotamus"
+msgstr ""
+
+#: src/lifesim_lib/const.py:181
+msgid "died due to smoke inhalation caused by a forest fire"
+msgstr ""
+
+#: src/lifesim_lib/const.py:182
+msgid "was killed in a fatal car crash"
+msgstr ""
+
+#: src/lifesim_lib/const.py:186 src/lifesim_lib/const.py:4667
+msgid "The Beatles"
+msgstr ""
+
+#: src/lifesim_lib/const.py:187 src/lifesim_lib/const.py:4415
+msgid "Eminem"
+msgstr ""
+
+#: src/lifesim_lib/const.py:188
+msgid "Michael Jackson"
+msgstr ""
+
+#: src/lifesim_lib/const.py:189
+msgid "Elton John"
+msgstr ""
+
+#: src/lifesim_lib/const.py:190
+msgid "Elvis Presley"
+msgstr ""
+
+#: src/lifesim_lib/const.py:191
+msgid "Rihanna"
+msgstr ""
+
+#: src/lifesim_lib/const.py:192
+msgid "Madonna"
+msgstr ""
+
+#: src/lifesim_lib/const.py:193 src/lifesim_lib/const.py:4668
+msgid "Pink Floyd"
+msgstr ""
+
+#: src/lifesim_lib/const.py:194
+msgid "Mariah Carey"
+msgstr ""
+
+#: src/lifesim_lib/const.py:195
+msgid "Taylor Swift"
+msgstr ""
+
+#: src/lifesim_lib/const.py:196
+msgid "Beyoncé"
+msgstr ""
+
+#: src/lifesim_lib/const.py:197
+msgid "Whitney Houston"
+msgstr ""
+
+#: src/lifesim_lib/const.py:198 src/lifesim_lib/const.py:4669
+msgid "The Rolling Stones"
+msgstr ""
+
+#: src/lifesim_lib/const.py:199
+msgid "Drake"
+msgstr ""
+
+#: src/lifesim_lib/const.py:200
+msgid "Justin Bieber"
+msgstr ""
+
+#: src/lifesim_lib/const.py:201
+msgid "Ed Sheeran"
+msgstr ""
+
+#: src/lifesim_lib/const.py:202
+msgid "Bruno Mars"
+msgstr ""
+
+#: src/lifesim_lib/const.py:230
+msgid "Carlton"
+msgstr ""
+
+#: src/lifesim_lib/const.py:231
+msgid "Dejo"
+msgstr ""
+
+#: src/lifesim_lib/const.py:232
+msgid "Lean"
+msgstr ""
+
+#: src/lifesim_lib/const.py:233
+msgid "Moonwalk"
+msgstr ""
+
+#: src/lifesim_lib/const.py:234
+msgid "Robot"
+msgstr ""
+
+#: src/lifesim_lib/const.py:235
+msgid "Running Man"
+msgstr ""
+
+#: src/lifesim_lib/const.py:236
+msgid "Single Ladies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:237
+msgid "Soulja Boy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:238
+msgid "Shoot"
+msgstr ""
+
+#: src/lifesim_lib/const.py:242 src/lifesim_lib/const.py:265
+msgid "an awkward"
+msgstr ""
+
+#: src/lifesim_lib/const.py:243
+msgid "a confident"
+msgstr ""
+
+#: src/lifesim_lib/const.py:244
+msgid "an enamouring"
+msgstr ""
+
+#: src/lifesim_lib/const.py:245
+msgid "a shy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:246
+msgid "a smooth"
+msgstr ""
+
+#: src/lifesim_lib/const.py:250
+msgid "at lunch"
+msgstr ""
+
+#: src/lifesim_lib/const.py:251
+msgid "by the pool"
+msgstr ""
+
+#: src/lifesim_lib/const.py:252
+msgid "by the sports fields"
+msgstr ""
+
+#: src/lifesim_lib/const.py:253
+msgid "during assembly"
+msgstr ""
+
+#: src/lifesim_lib/const.py:254
+msgid "in the gym"
+msgstr ""
+
+#: src/lifesim_lib/const.py:255
+msgid "in the library"
+msgstr ""
+
+#: src/lifesim_lib/const.py:256
+msgid "in english class"
+msgstr ""
+
+#: src/lifesim_lib/const.py:257
+msgid "in math class"
+msgstr ""
+
+#: src/lifesim_lib/const.py:258
+msgid "in science class"
+msgstr ""
+
+#: src/lifesim_lib/const.py:259
+msgid "on the way home from school"
+msgstr ""
+
+#: src/lifesim_lib/const.py:260
+msgid "on the way to school"
+msgstr ""
+
+#: src/lifesim_lib/const.py:264
+msgid "a"
+msgstr ""
+
+#: src/lifesim_lib/const.py:266
+msgid "a charmingly funny"
+msgstr ""
+
+#: src/lifesim_lib/const.py:267
+msgid "a flirtatious"
+msgstr ""
+
+#: src/lifesim_lib/const.py:280 src/lifesim_lib/const.py:1340
+#: src/lifesim_lib/const.py:1360 src/menus/main.py:987
+msgid "Art"
+msgstr ""
+
+#: src/lifesim_lib/const.py:281
+msgid "Careers"
+msgstr ""
+
+#: src/lifesim_lib/const.py:282
+msgid "Computer Science"
+msgstr ""
+
+#: src/lifesim_lib/const.py:283 src/lifesim_lib/const.py:393
+msgid "Drama"
+msgstr ""
+
+#: src/lifesim_lib/const.py:284
+msgid "English"
+msgstr ""
+
+#: src/lifesim_lib/const.py:285 src/lifesim_lib/const.py:433
+msgid "Geography"
+msgstr ""
+
+#: src/lifesim_lib/const.py:286
+msgid "History"
+msgstr ""
+
+#: src/lifesim_lib/const.py:287
+msgid "Math"
+msgstr ""
+
+#: src/lifesim_lib/const.py:288 src/menus/main.py:987
+msgid "Music"
+msgstr ""
+
+#: src/lifesim_lib/const.py:289
+msgid "Physical Eduacation"
+msgstr ""
+
+#: src/lifesim_lib/const.py:290
+msgid "Science"
+msgstr ""
+
+#: src/lifesim_lib/const.py:291
+msgid "Social Studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:307
+msgid "Accounting"
+msgstr ""
+
+#: src/lifesim_lib/const.py:308
+msgid "Business law"
+msgstr ""
+
+#: src/lifesim_lib/const.py:309
+msgid "Business management"
+msgstr ""
+
+#: src/lifesim_lib/const.py:310
+msgid "Consumer education"
+msgstr ""
+
+#: src/lifesim_lib/const.py:311
+msgid "Entrepreneurial skills"
+msgstr ""
+
+#: src/lifesim_lib/const.py:312
+msgid "Introduction to business"
+msgstr ""
+
+#: src/lifesim_lib/const.py:313
+msgid "Marketing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:314
+msgid "Personal finance"
+msgstr ""
+
+#: src/lifesim_lib/const.py:315
+msgid "Animation"
+msgstr ""
+
+#: src/lifesim_lib/const.py:316
+msgid "App development"
+msgstr ""
+
+#: src/lifesim_lib/const.py:317
+msgid "Audio production"
+msgstr ""
+
+#: src/lifesim_lib/const.py:318
+msgid "Computer programming"
+msgstr ""
+
+#: src/lifesim_lib/const.py:319
+msgid "Computer repair"
+msgstr ""
+
+#: src/lifesim_lib/const.py:320 src/lifesim_lib/const.py:457
+msgid "Film production"
+msgstr ""
+
+#: src/lifesim_lib/const.py:321
+msgid "Graphic design"
+msgstr ""
+
+#: src/lifesim_lib/const.py:322
+msgid "Media technology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:323
+msgid "Music production"
+msgstr ""
+
+#: src/lifesim_lib/const.py:324
+msgid "Typing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:325
+msgid "Video game development"
+msgstr ""
+
+#: src/lifesim_lib/const.py:326
+msgid "Web design"
+msgstr ""
+
+#: src/lifesim_lib/const.py:327
+msgid "Web programming"
+msgstr ""
+
+#: src/lifesim_lib/const.py:328
+msgid "Word processing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:329
+msgid "American literature"
+msgstr ""
+
+#: src/lifesim_lib/const.py:330
+msgid "British literature"
+msgstr ""
+
+#: src/lifesim_lib/const.py:331
+msgid "Contemporary literature"
+msgstr ""
+
+#: src/lifesim_lib/const.py:332
+msgid "Creative writing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:333
+msgid "Communication skills"
+msgstr ""
+
+#: src/lifesim_lib/const.py:334
+msgid "Debate"
+msgstr ""
+
+#: src/lifesim_lib/const.py:335
+msgid "English language and composition"
+msgstr ""
+
+#: src/lifesim_lib/const.py:336
+msgid "English literature and composition"
+msgstr ""
+
+#: src/lifesim_lib/const.py:337
+msgid "Humanities"
+msgstr ""
+
+#: src/lifesim_lib/const.py:338
+msgid "Journalism"
+msgstr ""
+
+#: src/lifesim_lib/const.py:339
+msgid "Literary analysis"
+msgstr ""
+
+#: src/lifesim_lib/const.py:340
+msgid "Modern literature"
+msgstr ""
+
+#: src/lifesim_lib/const.py:341
+msgid "Poetry"
+msgstr ""
+
+#: src/lifesim_lib/const.py:342
+msgid "Popular literature"
+msgstr ""
+
+#: src/lifesim_lib/const.py:343
+msgid "Rhetoric"
+msgstr ""
+
+#: src/lifesim_lib/const.py:344
+msgid "Technical writing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:345
+msgid "Works of Shakespeare"
+msgstr ""
+
+#: src/lifesim_lib/const.py:346
+msgid "World literature"
+msgstr ""
+
+#: src/lifesim_lib/const.py:347
+msgid "Written and oral communication"
+msgstr ""
+
+#: src/lifesim_lib/const.py:348
+msgid "Chemistry of foods"
+msgstr ""
+
+#: src/lifesim_lib/const.py:349
+msgid "CPR training"
+msgstr ""
+
+#: src/lifesim_lib/const.py:350
+msgid "Culinary arts"
+msgstr ""
+
+#: src/lifesim_lib/const.py:351
+msgid "Early childhood development"
+msgstr ""
+
+#: src/lifesim_lib/const.py:352
+msgid "Early childhood education"
+msgstr ""
+
+#: src/lifesim_lib/const.py:353
+msgid "Family studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:354
+msgid "Fashion and retail merchandising"
+msgstr ""
+
+#: src/lifesim_lib/const.py:355
+msgid "Fashion construction"
+msgstr ""
+
+#: src/lifesim_lib/const.py:356
+msgid "Home economics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:357
+msgid "Interior design"
+msgstr ""
+
+#: src/lifesim_lib/const.py:358
+msgid "Nutrition"
+msgstr ""
+
+#: src/lifesim_lib/const.py:359
+msgid "American Sign Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:360
+msgid "Ancient Greek Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:361
+msgid "Arabic Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:362
+msgid "Chinese Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:363
+msgid "French Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:364
+msgid "German Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:365
+msgid "Hebrew Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:366
+msgid "Italian Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:367
+msgid "Japanese Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:368
+msgid "Korean Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:369
+msgid "Latin Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:370
+msgid "Portuguese Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:371
+msgid "Russian Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:372
+msgid "Spanish Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:373
+msgid "Algebra 1"
+msgstr ""
+
+#: src/lifesim_lib/const.py:374
+msgid "Algebra 2"
+msgstr ""
+
+#: src/lifesim_lib/const.py:375
+msgid "Calculus"
+msgstr ""
+
+#: src/lifesim_lib/const.py:376
+msgid "Computer math"
+msgstr ""
+
+#: src/lifesim_lib/const.py:377
+msgid "Consumer math"
+msgstr ""
+
+#: src/lifesim_lib/const.py:378
+msgid "Fundamentals of math"
+msgstr ""
+
+#: src/lifesim_lib/const.py:379
+msgid "Geometry"
+msgstr ""
+
+#: src/lifesim_lib/const.py:380
+msgid "Integrated math"
+msgstr ""
+
+#: src/lifesim_lib/const.py:381
+msgid "Math applications"
+msgstr ""
+
+#: src/lifesim_lib/const.py:382
+msgid "Multivariable calculus"
+msgstr ""
+
+#: src/lifesim_lib/const.py:383
+msgid "Practical math"
+msgstr ""
+
+#: src/lifesim_lib/const.py:384
+msgid "Pre-algebra"
+msgstr ""
+
+#: src/lifesim_lib/const.py:385
+msgid "Pre-calculus"
+msgstr ""
+
+#: src/lifesim_lib/const.py:386
+msgid "Probability"
+msgstr ""
+
+#: src/lifesim_lib/const.py:387
+msgid "Quantitative literacy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:388
+msgid "Statistics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:389
+msgid "Trigonometry"
+msgstr ""
+
+#: src/lifesim_lib/const.py:390
+msgid "Choir"
+msgstr ""
+
+#: src/lifesim_lib/const.py:391
+msgid "Concert band"
+msgstr ""
+
+#: src/lifesim_lib/const.py:392 src/lifesim_lib/const.py:404
+msgid "Dance"
+msgstr ""
+
+#: src/lifesim_lib/const.py:394
+msgid "Guitar"
+msgstr ""
+
+#: src/lifesim_lib/const.py:395
+msgid "Jazz band"
+msgstr ""
+
+#: src/lifesim_lib/const.py:396
+msgid "Marching band"
+msgstr ""
+
+#: src/lifesim_lib/const.py:397
+msgid "Music theory"
+msgstr ""
+
+#: src/lifesim_lib/const.py:398
+msgid "Orchestra"
+msgstr ""
+
+#: src/lifesim_lib/const.py:399
+msgid "Percussion"
+msgstr ""
+
+#: src/lifesim_lib/const.py:400
+msgid "Piano"
+msgstr ""
+
+#: src/lifesim_lib/const.py:401
+msgid "Theater technology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:402 src/lifesim_lib/const.py:2225
+msgid "World music"
+msgstr ""
+
+#: src/lifesim_lib/const.py:403
+msgid "Aerobics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:405
+msgid "Gymnastics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:406 src/menus/main.py:1135
+#: src/people/classes/player.py:886
+msgid "Health"
+msgstr ""
+
+#: src/lifesim_lib/const.py:407
+msgid "Lifeguard training"
+msgstr ""
+
+#: src/lifesim_lib/const.py:408
+msgid "Pilates"
+msgstr ""
+
+#: src/lifesim_lib/const.py:409
+msgid "Racket sports"
+msgstr ""
+
+#: src/lifesim_lib/const.py:410
+msgid "Specialized sports"
+msgstr ""
+
+#: src/lifesim_lib/const.py:411
+msgid "Swimming"
+msgstr ""
+
+#: src/lifesim_lib/const.py:412
+msgid "Weight training"
+msgstr ""
+
+#: src/lifesim_lib/const.py:413
+msgid "Yoga"
+msgstr ""
+
+#: src/lifesim_lib/const.py:414
+msgid "Agriculture"
+msgstr ""
+
+#: src/lifesim_lib/const.py:415
+msgid "Astronomy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:416
+msgid "Biology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:417
+msgid "Botany"
+msgstr ""
+
+#: src/lifesim_lib/const.py:418
+msgid "Chemistry"
+msgstr ""
+
+#: src/lifesim_lib/const.py:419
+msgid "Earth science"
+msgstr ""
+
+#: src/lifesim_lib/const.py:420 src/lifesim_lib/const.py:470
+msgid "Electronics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:421
+msgid "Environmental science"
+msgstr ""
+
+#: src/lifesim_lib/const.py:422
+msgid "Environmental studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:423
+msgid "Forensic science"
+msgstr ""
+
+#: src/lifesim_lib/const.py:424
+msgid "Geology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:425
+msgid "Marine biology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:426
+msgid "Oceanography"
+msgstr ""
+
+#: src/lifesim_lib/const.py:427
+msgid "Physical science"
+msgstr ""
+
+#: src/lifesim_lib/const.py:428
+msgid "Physics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:429
+msgid "Zoology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:430
+msgid "Cultural anthropology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:431
+msgid "Current events"
+msgstr ""
+
+#: src/lifesim_lib/const.py:432
+msgid "European history"
+msgstr ""
+
+#: src/lifesim_lib/const.py:434
+msgid "Global studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:435
+msgid "Human geography"
+msgstr ""
+
+#: src/lifesim_lib/const.py:436
+msgid "International relations"
+msgstr ""
+
+#: src/lifesim_lib/const.py:437
+msgid "Law"
+msgstr ""
+
+#: src/lifesim_lib/const.py:438
+msgid "Macroeconomics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:439
+msgid "Microeconomics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:440
+msgid "Modern world studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:441
+msgid "Physical anthropology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:442
+msgid "Political studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:443
+msgid "Psychology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:444
+msgid "Religious studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:445
+msgid "Sociology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:446
+msgid "National government"
+msgstr ""
+
+#: src/lifesim_lib/const.py:447
+msgid "National history"
+msgstr ""
+
+#: src/lifesim_lib/const.py:448
+msgid "Women's studies"
+msgstr ""
+
+#: src/lifesim_lib/const.py:449
+msgid "World history"
+msgstr ""
+
+#: src/lifesim_lib/const.py:450
+msgid "World politics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:451
+msgid "World religions"
+msgstr ""
+
+#: src/lifesim_lib/const.py:452
+msgid "3-D art"
+msgstr ""
+
+#: src/lifesim_lib/const.py:453
+msgid "Art history"
+msgstr ""
+
+#: src/lifesim_lib/const.py:454
+msgid "Ceramics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:455
+msgid "Digital media"
+msgstr ""
+
+#: src/lifesim_lib/const.py:456
+msgid "Drawing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:458
+msgid "Jewelry design"
+msgstr ""
+
+#: src/lifesim_lib/const.py:459
+msgid "Painting"
+msgstr ""
+
+#: src/lifesim_lib/const.py:460
+msgid "Photography"
+msgstr ""
+
+#: src/lifesim_lib/const.py:461
+msgid "Printmaking"
+msgstr ""
+
+#: src/lifesim_lib/const.py:462
+msgid "Sculpture"
+msgstr ""
+
+#: src/lifesim_lib/const.py:463
+msgid "Auto body repair"
+msgstr ""
+
+#: src/lifesim_lib/const.py:464
+msgid "Auto mechanics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:465
+msgid "Building construction"
+msgstr ""
+
+#: src/lifesim_lib/const.py:466
+msgid "Computer-aided drafting"
+msgstr ""
+
+#: src/lifesim_lib/const.py:467
+msgid "Cosmetology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:468
+msgid "Criminal justice"
+msgstr ""
+
+#: src/lifesim_lib/const.py:469
+msgid "Driver education"
+msgstr ""
+
+#: src/lifesim_lib/const.py:471
+msgid "FFA (Future Farmers of America)"
+msgstr ""
+
+#: src/lifesim_lib/const.py:472
+msgid "Fire science"
+msgstr ""
+
+#: src/lifesim_lib/const.py:473
+msgid "Heating and cooling systems"
+msgstr ""
+
+#: src/lifesim_lib/const.py:474
+msgid "Hospitality and tourism"
+msgstr ""
+
+#: src/lifesim_lib/const.py:475
+msgid "JROTC (Junior Reserve Officers' Training Corps)"
+msgstr ""
+
+#: src/lifesim_lib/const.py:476
+msgid "Metalworking"
+msgstr ""
+
+#: src/lifesim_lib/const.py:477
+msgid "Networking"
+msgstr ""
+
+#: src/lifesim_lib/const.py:478
+msgid "Plumbing"
+msgstr ""
+
+#: src/lifesim_lib/const.py:479
+msgid "Production technology"
+msgstr ""
+
+#: src/lifesim_lib/const.py:480
+msgid "Refrigeration fundamentals"
+msgstr ""
+
+#: src/lifesim_lib/const.py:481 src/lifesim_lib/const.py:1278
+msgid "Robotics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:482
+msgid "Woodworking"
+msgstr ""
+
+#: src/lifesim_lib/const.py:486
+msgid "Ooh La La!"
+msgstr ""
+
+#: src/lifesim_lib/const.py:487
+msgid "Why, hello there!"
+msgstr ""
+
+#: src/lifesim_lib/const.py:508
+msgid "You have a hard time walking straight the next day"
+msgstr ""
+
+#: src/lifesim_lib/const.py:509 src/lifesim_lib/const.py:516
+msgid "You left your underwear behind"
+msgstr ""
+
+#: src/lifesim_lib/const.py:512 src/lifesim_lib/const.py:519
+#: src/lifesim_lib/const.py:554 src/lifesim_lib/const.py:672
+#: src/lifesim_lib/const.py:728 src/lifesim_lib/const.py:743
+#: src/lifesim_lib/const.py:761 src/lifesim_lib/const.py:765
+#: src/lifesim_lib/const.py:773 src/lifesim_lib/const.py:777
+#: src/lifesim_lib/const.py:781 src/lifesim_lib/const.py:786
+#: src/lifesim_lib/const.py:791 src/lifesim_lib/const.py:795
+#: src/lifesim_lib/const.py:823 src/lifesim_lib/const.py:834
+#: src/lifesim_lib/const.py:850 src/lifesim_lib/const.py:859
+#: src/lifesim_lib/const.py:863 src/lifesim_lib/const.py:867
+#: src/lifesim_lib/const.py:871 src/lifesim_lib/const.py:875
+#: src/lifesim_lib/const.py:879 src/lifesim_lib/const.py:887
+#: src/lifesim_lib/const.py:891 src/lifesim_lib/const.py:935
+#: src/lifesim_lib/const.py:939 src/lifesim_lib/const.py:943
+#: src/lifesim_lib/const.py:955 src/lifesim_lib/const.py:972
+#: src/lifesim_lib/const.py:973 src/lifesim_lib/const.py:977
+#: src/lifesim_lib/const.py:978 src/lifesim_lib/const.py:983
+#: src/lifesim_lib/const.py:989 src/lifesim_lib/const.py:995
+#: src/lifesim_lib/const.py:1025 src/lifesim_lib/const.py:1029
+#: src/lifesim_lib/const.py:1034 src/lifesim_lib/const.py:1038
+#: src/lifesim_lib/const.py:1246 src/lifesim_lib/const.py:2246
+#: src/lifesim_lib/const.py:2377 src/lifesim_lib/const.py:2935
+#: src/lifesim_lib/const.py:3430 src/lifesim_lib/const.py:3433
+#: src/lifesim_lib/const.py:3436 src/lifesim_lib/const.py:3439
+#: src/lifesim_lib/const.py:3442 src/lifesim_lib/const.py:3445
+#: src/lifesim_lib/const.py:3667 src/lifesim_lib/const.py:3679
+#: src/lifesim_lib/const.py:3813 src/lifesim_lib/const.py:3816
+#: src/lifesim_lib/const.py:3823 src/lifesim_lib/const.py:3828
+#: src/lifesim_lib/const.py:4861 src/lifesim_lib/const.py:4862
+#: src/lifesim_lib/const.py:4876 src/lifesim_lib/const.py:5073
+msgid ""
+msgstr ""
+
+#: src/lifesim_lib/const.py:529
+msgid "A :dude"
+msgstr ""
+
+#: src/lifesim_lib/const.py:530
+msgid "A guy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:531
+msgid "An interesting guy"
+msgstr ""
+
+#: src/lifesim_lib/const.py:534
+msgid "invites you to exchange nude pics"
+msgstr ""
+
+#: src/lifesim_lib/const.py:544
+msgid "got up and left"
+msgstr ""
+
+#: src/lifesim_lib/const.py:557 src/lifesim_lib/const.py:582
+#: src/lifesim_lib/const.py:607 src/lifesim_lib/const.py:1129
+msgid "Principal"
+msgstr ""
+
+#: src/lifesim_lib/const.py:558 src/lifesim_lib/const.py:583
+#: src/lifesim_lib/const.py:608 src/lifesim_lib/const.py:951
+#: src/lifesim_lib/const.py:1128
+msgid "Assistant Principal"
+msgstr ""
+
+#: src/lifesim_lib/const.py:559 src/lifesim_lib/const.py:584
+#: src/lifesim_lib/const.py:609
+msgid "Administrator"
+msgstr ""
+
+#: src/lifesim_lib/const.py:560 src/lifesim_lib/const.py:585
+#: src/lifesim_lib/const.py:610
+msgid "Cleaner"
+msgstr ""
+
+#: src/lifesim_lib/const.py:561 src/lifesim_lib/const.py:586
+#: src/lifesim_lib/const.py:612
+msgid "Executive Assistant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:562 src/lifesim_lib/const.py:587
+#: src/lifesim_lib/const.py:613 src/lifesim_lib/const.py:625
+#: src/lifesim_lib/const.py:635
+msgid "Food Service"
+msgstr ""
+
+#: src/lifesim_lib/const.py:563 src/lifesim_lib/const.py:588
+#: src/lifesim_lib/const.py:614 src/lifesim_lib/const.py:626
+#: src/lifesim_lib/const.py:636
+msgid "Groundskeeper"
+msgstr ""
+
+#: src/lifesim_lib/const.py:564 src/lifesim_lib/const.py:589
+#: src/lifesim_lib/const.py:615
+msgid "Substitute Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:568 src/lifesim_lib/const.py:594
+msgid "Art Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:569
+msgid "Careers Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:570
+msgid "IT Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:571 src/lifesim_lib/const.py:597
+msgid "Drama Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:572 src/lifesim_lib/const.py:599
+msgid "English Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:573
+msgid "Geography Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:574
+msgid "History Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:575 src/lifesim_lib/const.py:601
+msgid "Math Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:576 src/lifesim_lib/const.py:602
+msgid "Music Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:577 src/lifesim_lib/const.py:603
+msgid "P.E. Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:578
+msgid "Science Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:579
+msgid "Social Studies Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:593
+msgid "Accounting Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:595
+msgid "Chemistry Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:596
+msgid "Computer Science Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:598
+msgid "Economics Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:600
+msgid "Foreign Language"
+msgstr ""
+
+#: src/lifesim_lib/const.py:604
+msgid "Physics Teacher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:611
+msgid "Careers Counsellor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:619 src/lifesim_lib/const.py:629
+msgid "Associate Professor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:620 src/lifesim_lib/const.py:629
+#: src/lifesim_lib/const.py:1033 src/lifesim_lib/const.py:1057
+#: src/lifesim_lib/const.py:1125
+msgid "Professor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:621 src/lifesim_lib/const.py:629
+msgid "Researcher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:624 src/lifesim_lib/const.py:631
+msgid "Dean"
+msgstr ""
+
+#: src/lifesim_lib/const.py:632
+msgid "Associate Dean"
+msgstr ""
+
+#: src/lifesim_lib/const.py:633
+msgid "Chancellor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:634
+msgid "Director of Education"
+msgstr ""
+
+#: src/lifesim_lib/const.py:637
+msgid "Librarian"
+msgstr ""
+
+#: src/lifesim_lib/const.py:638 src/lifesim_lib/const.py:1645
+msgid "President"
+msgstr ""
+
+#: src/lifesim_lib/const.py:639
+msgid "Vice Chancellor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:640
+msgid "Vice President"
+msgstr ""
+
+#: src/lifesim_lib/const.py:646
+msgid "High School Dropout"
+msgstr ""
+
+#: src/lifesim_lib/const.py:647
+msgid "High School Student"
+msgstr ""
+
+#: src/lifesim_lib/const.py:648
+msgid "High School Student, Part-time Arcade Assistant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:649
+msgid "High School Student, Part-time Armpit Sniffer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:650
+msgid "High School Student, Part-time Barista"
+msgstr ""
+
+#: src/lifesim_lib/const.py:651
+msgid "High School Student, Part-time Bike Shop Mechanic"
+msgstr ""
+
+#: src/lifesim_lib/const.py:652
+msgid "High School Student, Part-time Boutique Associate"
+msgstr ""
+
+#: src/lifesim_lib/const.py:653
+msgid "High School Student, Part-time Bowling Alley Assistant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:654
+msgid "High School Student, Part-time Camp Counsellor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:655
+msgid "High School Student, Part-time Car Wash Attendant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:656
+msgid "High School Student, Part-time Dance Instructor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:657
+msgid "High School Student, Part-time Doorman"
+msgstr ""
+
+#: src/lifesim_lib/const.py:658
+msgid "High School Student, Part-time Fitness Instructor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:659
+msgid "High School Student, Part-time Gym Receptionist"
+msgstr ""
+
+#: src/lifesim_lib/const.py:660
+msgid "High School Student, Part-time Hotel Concierge"
+msgstr ""
+
+#: src/lifesim_lib/const.py:661
+msgid "High School Student, Part-time Ice Cream Scooper"
+msgstr ""
+
+#: src/lifesim_lib/const.py:662
+msgid "High School Student, Part-time Lifeguard"
+msgstr ""
+
+#: src/lifesim_lib/const.py:663
+msgid "High School Student, Part-time Mall Kiosk Worker"
+msgstr ""
+
+#: src/lifesim_lib/const.py:664
+msgid "High School Student, Part-time Personal Trainer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:665
+msgid "High School Student, Part-time Usher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:666
+msgid "High School Student, Part-time Valet"
+msgstr ""
+
+#: src/lifesim_lib/const.py:667
+msgid "High School Student, Part-time Window Cleaner"
+msgstr ""
+
+#: src/lifesim_lib/const.py:671 src/people/classes/player.py:151
+msgid "Unemployed"
+msgstr ""
+
+#: src/lifesim_lib/const.py:677
+msgid "Handyman"
+msgstr ""
+
+#: src/lifesim_lib/const.py:678
+msgid "Tutor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:679
+msgid "Caretaker"
+msgstr ""
+
+#: src/lifesim_lib/const.py:680
+msgid "Lawn Mower"
+msgstr ""
+
+#: src/lifesim_lib/const.py:681
+msgid "Babysitter"
+msgstr ""
+
+#: src/lifesim_lib/const.py:682
+msgid "Dog Walker"
+msgstr ""
+
+#: src/lifesim_lib/const.py:683
+msgid "Pet Sitter"
+msgstr ""
+
+#: src/lifesim_lib/const.py:684
+msgid "Lemonade Stand"
+msgstr ""
+
+#: src/lifesim_lib/const.py:685
+msgid "Kissing booth"
+msgstr ""
+
+#: src/lifesim_lib/const.py:688 src/lifesim_lib/const.py:737
+msgid "Arcade Assistant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:689
+msgid "Armpit Sniffer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:690
+msgid "Barista"
+msgstr ""
+
+#: src/lifesim_lib/const.py:691
+msgid "Bellhop"
+msgstr ""
+
+#: src/lifesim_lib/const.py:692
+msgid "Bike Shop Mechanic"
+msgstr ""
+
+#: src/lifesim_lib/const.py:693
+msgid "Bookkeeper"
+msgstr ""
+
+#: src/lifesim_lib/const.py:694
+msgid "Boutique Associate"
+msgstr ""
+
+#: src/lifesim_lib/const.py:695
+msgid "Bowling Alley Assistant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:696
+msgid "Camp Counsellor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:697 src/lifesim_lib/const.py:727
+msgid "Car Wash Attendant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:698
+msgid "Caterer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:699
+msgid "Collections Specialist"
+msgstr ""
+
+#: src/lifesim_lib/const.py:700 src/lifesim_lib/const.py:740
+msgid "Concessions Attendant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:701
+msgid "Dance Instructor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:702
+msgid "Delivery Driver"
+msgstr ""
+
+#: src/lifesim_lib/const.py:703
+msgid "Doorman"
+msgstr ""
+
+#: src/lifesim_lib/const.py:704
+msgid "Fitness Instructor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:705
+msgid "Gym Receptionist"
+msgstr ""
+
+#: src/lifesim_lib/const.py:706
+msgid "Hotel Concierge"
+msgstr ""
+
+#: src/lifesim_lib/const.py:707
+msgid "Hotel Front Desk Clerk"
+msgstr ""
+
+#: src/lifesim_lib/const.py:708
+msgid "Ice Cream Scooper"
+msgstr ""
+
+#: src/lifesim_lib/const.py:709
+msgid "Lifeguard"
+msgstr ""
+
+#: src/lifesim_lib/const.py:710
+msgid "Mall Kiosk Worker"
+msgstr ""
+
+#: src/lifesim_lib/const.py:711
+msgid "Mall Santa"
+msgstr ""
+
+#: src/lifesim_lib/const.py:712
+msgid "Office Assistant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:713
+msgid "Personal Trainer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:714 src/lifesim_lib/const.py:734
+msgid "Pool Towel Attendant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:715
+msgid "Sandwich Maker"
+msgstr ""
+
+#: src/lifesim_lib/const.py:716
+msgid "School Bus Driver"
+msgstr ""
+
+#: src/lifesim_lib/const.py:717
+msgid "Sign Holder"
+msgstr ""
+
+#: src/lifesim_lib/const.py:718 src/lifesim_lib/const.py:744
+msgid "Street Sweeper"
+msgstr ""
+
+#: src/lifesim_lib/const.py:719
+msgid "Swim Instructor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:720
+msgid "Usher"
+msgstr ""
+
+#: src/lifesim_lib/const.py:721
+msgid "Valet"
+msgstr ""
+
+#: src/lifesim_lib/const.py:722
+msgid "Window Cleaner"
+msgstr ""
+
+#: src/lifesim_lib/const.py:723 src/lifesim_lib/const.py:731
+msgid "Yoga Receptionist"
+msgstr ""
+
+#: src/lifesim_lib/const.py:752
+msgid "Fluffer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:753 src/lifesim_lib/const.py:1073
+msgid "Porn Actor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:754 src/lifesim_lib/const.py:1074
+msgid "Porn Cameraman"
+msgstr ""
+
+#: src/lifesim_lib/const.py:755 src/lifesim_lib/const.py:1075
+msgid "Porn Star"
+msgstr ""
+
+#: src/lifesim_lib/const.py:756 src/lifesim_lib/const.py:1076
+msgid "Porn Writer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:757 src/lifesim_lib/const.py:1077
+msgid "Porn Director"
+msgstr ""
+
+#: src/lifesim_lib/const.py:760
+msgid "Junior App Developer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:764
+msgid "App Developer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:768 src/lifesim_lib/const.py:772
+msgid "Baggage Handler"
+msgstr ""
+
+#: src/lifesim_lib/const.py:769
+msgid "Junior Flight Attendant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:776
+msgid "Junior Architect"
+msgstr ""
+
+#: src/lifesim_lib/const.py:780
+msgid "Architect"
+msgstr ""
+
+#: src/lifesim_lib/const.py:784
+msgid "Apprentice Auto Mechanic"
+msgstr ""
+
+#: src/lifesim_lib/const.py:785
+msgid "Apprentice Auto Electrician"
+msgstr ""
+
+#: src/lifesim_lib/const.py:789
+msgid "Auto Mechanic"
+msgstr ""
+
+#: src/lifesim_lib/const.py:790
+msgid "Auto Electrician"
+msgstr ""
+
+#: src/lifesim_lib/const.py:794
+msgid "Deacon"
+msgstr ""
+
+#: src/lifesim_lib/const.py:798
+msgid "Acrobat"
+msgstr ""
+
+#: src/lifesim_lib/const.py:799
+msgid "Clown"
+msgstr ""
+
+#: src/lifesim_lib/const.py:800 src/lifesim_lib/const.py:858
+msgid "Dancer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:801
+msgid "Fire Breather"
+msgstr ""
+
+#: src/lifesim_lib/const.py:802
+msgid "Fire Eater"
+msgstr ""
+
+#: src/lifesim_lib/const.py:803
+msgid "Horse Rider"
+msgstr ""
+
+#: src/lifesim_lib/const.py:804
+msgid "Juggler"
+msgstr ""
+
+#: src/lifesim_lib/const.py:805
+msgid "Lion Tamer"
+msgstr ""
+
+#: src/lifesim_lib/const.py:806
+msgid "Magician"
+msgstr ""
+
+#: src/lifesim_lib/const.py:807
+msgid "Magician's Assistant"
+msgstr ""
+
 #: src/lifesim_lib/const.py:808
-msgid "Junior Computer Programmer"
+msgid "Plate Spinner"
 msgstr ""
 
 #: src/lifesim_lib/const.py:809
-msgid "Junior Database Administrator"
+msgid "Sword Eater"
 msgstr ""
 
-#: src/lifesim_lib/const.py:810 src/lifesim_lib/const.py:1092
-msgid "Junior Financial Advisor"
+#: src/lifesim_lib/const.py:810
+msgid "Tightrope Walker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:811 src/lifesim_lib/const.py:1096
-msgid "Junior Financial Analyst"
+#: src/lifesim_lib/const.py:811
+msgid "Trapeze Artist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:812 src/lifesim_lib/const.py:1105
-msgid "Junior Internal Auditor"
+#: src/lifesim_lib/const.py:812
+msgid "Unicyclist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:813 src/lifesim_lib/const.py:1112
-msgid "Junior Lobbyist"
+#: src/lifesim_lib/const.py:815 src/lifesim_lib/const.py:826
+msgid "Administrative Assistant"
+msgstr ""
+
+#: src/lifesim_lib/const.py:817
+msgid "Junior Computer Programmer"
 msgstr ""
 
 #: src/lifesim_lib/const.py:818
+msgid "Junior Database Administrator"
+msgstr ""
+
+#: src/lifesim_lib/const.py:819 src/lifesim_lib/const.py:1101
+msgid "Junior Financial Advisor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:820 src/lifesim_lib/const.py:1105
+msgid "Junior Financial Analyst"
+msgstr ""
+
+#: src/lifesim_lib/const.py:821 src/lifesim_lib/const.py:1114
+msgid "Junior Internal Auditor"
+msgstr ""
+
+#: src/lifesim_lib/const.py:822 src/lifesim_lib/const.py:1121
+msgid "Junior Lobbyist"
+msgstr ""
+
+#: src/lifesim_lib/const.py:827
 msgid "Computer Programmer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:820 src/lifesim_lib/const.py:1091
+#: src/lifesim_lib/const.py:829 src/lifesim_lib/const.py:1100
 msgid "Financial Advisor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:821 src/lifesim_lib/const.py:1095
+#: src/lifesim_lib/const.py:830 src/lifesim_lib/const.py:1104
 msgid "Financial Analyst"
 msgstr ""
 
-#: src/lifesim_lib/const.py:822 src/lifesim_lib/const.py:1104
+#: src/lifesim_lib/const.py:831 src/lifesim_lib/const.py:1113
 msgid "Internal Auditor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:823 src/lifesim_lib/const.py:1113
+#: src/lifesim_lib/const.py:832 src/lifesim_lib/const.py:1122
 msgid "Lobbyist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:824
+#: src/lifesim_lib/const.py:833
 msgid "Receptionist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:828 src/lifesim_lib/const.py:1087
+#: src/lifesim_lib/const.py:837 src/lifesim_lib/const.py:1096
 msgid "Dental Hygenist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:829
+#: src/lifesim_lib/const.py:838
 msgid "Dental Receptionist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:830 src/lifesim_lib/const.py:1088
+#: src/lifesim_lib/const.py:839 src/lifesim_lib/const.py:1097
 msgid "Dentist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:833
+#: src/lifesim_lib/const.py:842
 msgid "Junior Microbiologist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:836 src/lifesim_lib/const.py:1045
-#: src/lifesim_lib/const.py:1084
+#: src/lifesim_lib/const.py:845 src/lifesim_lib/const.py:1054
+#: src/lifesim_lib/const.py:1093
 msgid "Engineer I"
 msgstr ""
 
-#: src/lifesim_lib/const.py:837
+#: src/lifesim_lib/const.py:846
 msgid "Environmental Scientist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:840
+#: src/lifesim_lib/const.py:849
 msgid "Escort"
 msgstr ""
 
-#: src/lifesim_lib/const.py:844
+#: src/lifesim_lib/const.py:853
 msgid "Crew Member"
 msgstr ""
 
-#: src/lifesim_lib/const.py:845 src/lifesim_lib/const.py:921
+#: src/lifesim_lib/const.py:854 src/lifesim_lib/const.py:930
 msgid "Manager"
 msgstr ""
 
-#: src/lifesim_lib/const.py:846
+#: src/lifesim_lib/const.py:855
 msgid "Team Leader"
 msgstr ""
 
-#: src/lifesim_lib/const.py:853 src/lifesim_lib/const.py:979
+#: src/lifesim_lib/const.py:862 src/lifesim_lib/const.py:988
 msgid "Apprentice Grocer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:857 src/lifesim_lib/const.py:985
+#: src/lifesim_lib/const.py:866 src/lifesim_lib/const.py:994
 msgid "Grocer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:861
+#: src/lifesim_lib/const.py:870
 msgid "Brain Surgeon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:865
+#: src/lifesim_lib/const.py:874
 msgid "Factory Worker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:869
+#: src/lifesim_lib/const.py:878
 msgid "Insurance Agent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:873
+#: src/lifesim_lib/const.py:882
 msgid "Sales Associate"
 msgstr ""
 
-#: src/lifesim_lib/const.py:874
+#: src/lifesim_lib/const.py:883
 msgid "Jeweller"
 msgstr ""
 
-#: src/lifesim_lib/const.py:877 src/lifesim_lib/const.py:1108
+#: src/lifesim_lib/const.py:886 src/lifesim_lib/const.py:1117
 msgid "Junior Associate"
 msgstr ""
 
-#: src/lifesim_lib/const.py:881
+#: src/lifesim_lib/const.py:890
 msgid "Legal Secretary"
 msgstr ""
 
-#: src/lifesim_lib/const.py:885
+#: src/lifesim_lib/const.py:894
 msgid "Mall Cop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:886
+#: src/lifesim_lib/const.py:895
 msgid "Facilities Manager"
 msgstr ""
 
-#: src/lifesim_lib/const.py:889 src/lifesim_lib/const.py:1071
+#: src/lifesim_lib/const.py:898 src/lifesim_lib/const.py:1080
 msgid "Catalogue Model"
 msgstr ""
 
-#: src/lifesim_lib/const.py:890 src/lifesim_lib/const.py:1072
+#: src/lifesim_lib/const.py:899 src/lifesim_lib/const.py:1081
 msgid "Foot Model"
 msgstr ""
 
-#: src/lifesim_lib/const.py:891 src/lifesim_lib/const.py:1073
+#: src/lifesim_lib/const.py:900 src/lifesim_lib/const.py:1082
 msgid "Hand Model"
 msgstr ""
 
-#: src/lifesim_lib/const.py:892 src/lifesim_lib/const.py:1074
+#: src/lifesim_lib/const.py:901 src/lifesim_lib/const.py:1083
 msgid "Fit Model"
 msgstr ""
 
-#: src/lifesim_lib/const.py:893 src/lifesim_lib/const.py:1075
+#: src/lifesim_lib/const.py:902 src/lifesim_lib/const.py:1084
 msgid "Lingerie Model"
 msgstr ""
 
-#: src/lifesim_lib/const.py:894
+#: src/lifesim_lib/const.py:903
 msgid "Model Scout"
 msgstr ""
 
-#: src/lifesim_lib/const.py:895
+#: src/lifesim_lib/const.py:904
 msgid "Modelling Agent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:896 src/lifesim_lib/const.py:1076
+#: src/lifesim_lib/const.py:905 src/lifesim_lib/const.py:1085
 msgid "Photo Model"
 msgstr ""
 
-#: src/lifesim_lib/const.py:897 src/lifesim_lib/const.py:1077
+#: src/lifesim_lib/const.py:906 src/lifesim_lib/const.py:1086
 msgid "Runway Model"
 msgstr ""
 
-#: src/lifesim_lib/const.py:900 src/lifesim_lib/const.py:994
-#: src/lifesim_lib/const.py:1081
+#: src/lifesim_lib/const.py:909 src/lifesim_lib/const.py:1003
+#: src/lifesim_lib/const.py:1090
 msgid "Cameraman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:901 src/lifesim_lib/const.py:999
+#: src/lifesim_lib/const.py:910 src/lifesim_lib/const.py:1008
 msgid "Director"
 msgstr ""
 
-#: src/lifesim_lib/const.py:902 src/lifesim_lib/const.py:1002
+#: src/lifesim_lib/const.py:911 src/lifesim_lib/const.py:1011
 msgid "Key Grip"
 msgstr ""
 
-#: src/lifesim_lib/const.py:905
+#: src/lifesim_lib/const.py:914
 msgid "Junior Policy Analyst"
 msgstr ""
 
-#: src/lifesim_lib/const.py:906
+#: src/lifesim_lib/const.py:915
 msgid "Junior Mail Carrier"
 msgstr ""
 
-#: src/lifesim_lib/const.py:909
+#: src/lifesim_lib/const.py:918
 msgid "Bus Driver"
 msgstr ""
 
-#: src/lifesim_lib/const.py:910 src/lifesim_lib/const.py:1051
-#: src/lifesim_lib/const.py:1109
+#: src/lifesim_lib/const.py:919 src/lifesim_lib/const.py:1060
+#: src/lifesim_lib/const.py:1118
 msgid "Magistrate"
 msgstr ""
 
-#: src/lifesim_lib/const.py:911
+#: src/lifesim_lib/const.py:920
 msgid "Mail Carrier"
 msgstr ""
 
-#: src/lifesim_lib/const.py:914
+#: src/lifesim_lib/const.py:923
 msgid "Museum Docent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:915
+#: src/lifesim_lib/const.py:924
 msgid "Gallery Associate"
 msgstr ""
 
-#: src/lifesim_lib/const.py:918 src/lifesim_lib/const.py:937
-#: src/lifesim_lib/const.py:1038 src/lifesim_lib/const.py:1099
+#: src/lifesim_lib/const.py:927 src/lifesim_lib/const.py:946
+#: src/lifesim_lib/const.py:1047 src/lifesim_lib/const.py:1108
 msgid "Bartender"
 msgstr ""
 
-#: src/lifesim_lib/const.py:919
+#: src/lifesim_lib/const.py:928
 msgid "DJ"
 msgstr ""
 
-#: src/lifesim_lib/const.py:920 src/lifesim_lib/const.py:939
-#: src/lifesim_lib/const.py:1100
+#: src/lifesim_lib/const.py:929 src/lifesim_lib/const.py:948
+#: src/lifesim_lib/const.py:1109
 msgid "Host"
 msgstr ""
 
-#: src/lifesim_lib/const.py:922
+#: src/lifesim_lib/const.py:931
 msgid "Security"
 msgstr ""
 
-#: src/lifesim_lib/const.py:925
+#: src/lifesim_lib/const.py:934
 msgid "Real Estate Agent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:929
+#: src/lifesim_lib/const.py:938
 msgid "Retail Salesperson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:933
+#: src/lifesim_lib/const.py:942
 msgid "Driver"
 msgstr ""
 
-#: src/lifesim_lib/const.py:938
+#: src/lifesim_lib/const.py:947
 msgid "Server"
 msgstr ""
 
-#: src/lifesim_lib/const.py:945
+#: src/lifesim_lib/const.py:954
 msgid "Massage Therapist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:949
+#: src/lifesim_lib/const.py:958
 msgid "Apprentice Moonshiner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:950
+#: src/lifesim_lib/const.py:959
 msgid "Apprentice Tailor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:951 src/lifesim_lib/const.py:957
+#: src/lifesim_lib/const.py:960 src/lifesim_lib/const.py:966
 msgid "Junior Animator"
 msgstr ""
 
-#: src/lifesim_lib/const.py:952
+#: src/lifesim_lib/const.py:961
 msgid "Junior Graphic Designer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:955
+#: src/lifesim_lib/const.py:964
 msgid "Construction Worker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:956
+#: src/lifesim_lib/const.py:965
 msgid "Housekeeper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:958
+#: src/lifesim_lib/const.py:967
 msgid "Road Kill Remover"
 msgstr ""
 
-#: src/lifesim_lib/const.py:959
+#: src/lifesim_lib/const.py:968
 msgid "Water Slide Tester"
 msgstr ""
 
-#: src/lifesim_lib/const.py:962
+#: src/lifesim_lib/const.py:971
 msgid "Junior Stockbroker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:967
+#: src/lifesim_lib/const.py:976
 msgid "Stockbroker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:972
+#: src/lifesim_lib/const.py:981
 msgid "Exotic Dancer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:973
+#: src/lifesim_lib/const.py:982
 msgid "Pole Cleaner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:977
+#: src/lifesim_lib/const.py:986
 msgid "Apprentice Baker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:978
+#: src/lifesim_lib/const.py:987
 msgid "Apprentice Butcher"
 msgstr ""
 
-#: src/lifesim_lib/const.py:983
+#: src/lifesim_lib/const.py:992
 msgid "Baker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:984
+#: src/lifesim_lib/const.py:993
 msgid "Butcher"
 msgstr ""
 
-#: src/lifesim_lib/const.py:989
+#: src/lifesim_lib/const.py:998
 msgid "Junior Cameraman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:990
+#: src/lifesim_lib/const.py:999
 msgid "Junior Reporter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:993
+#: src/lifesim_lib/const.py:1002
 msgid "Animator"
 msgstr ""
 
-#: src/lifesim_lib/const.py:995
+#: src/lifesim_lib/const.py:1004
 msgid "Cinematographer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:996
+#: src/lifesim_lib/const.py:1005
 msgid "Casting Director"
 msgstr ""
 
-#: src/lifesim_lib/const.py:997
+#: src/lifesim_lib/const.py:1006
 msgid "Comedian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:998
+#: src/lifesim_lib/const.py:1007
 msgid "Costume Designer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1000
+#: src/lifesim_lib/const.py:1009
 msgid "Director of Photography"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1001
+#: src/lifesim_lib/const.py:1010
 msgid "Editor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1003
+#: src/lifesim_lib/const.py:1012
 msgid "Music Director"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1004
+#: src/lifesim_lib/const.py:1013
 msgid "News Reporter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1005
+#: src/lifesim_lib/const.py:1014
 msgid "Production Designer and Art Director"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1006
+#: src/lifesim_lib/const.py:1015
 msgid "Sound Editor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1007
+#: src/lifesim_lib/const.py:1016
 msgid "Talkshow Host"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1008
+#: src/lifesim_lib/const.py:1017
 msgid "Writer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1011
+#: src/lifesim_lib/const.py:1020
 msgid "Tour Operator"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1012
+#: src/lifesim_lib/const.py:1021
 msgid "Travel Associate"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1015
+#: src/lifesim_lib/const.py:1024
 msgid "Apprentice Trucker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1019
+#: src/lifesim_lib/const.py:1028
 msgid "Trucker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1023
+#: src/lifesim_lib/const.py:1032
 msgid "Archaeologist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1028 src/lifesim_lib/const.py:1032
-#: src/lifesim_lib/const.py:1123
+#: src/lifesim_lib/const.py:1037 src/lifesim_lib/const.py:1041
+#: src/lifesim_lib/const.py:1132
 msgid "Junior Veterinarian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1033 src/lifesim_lib/const.py:1124
+#: src/lifesim_lib/const.py:1042 src/lifesim_lib/const.py:1133
 msgid "Veterinarian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1041 src/lifesim_lib/const.py:1080
+#: src/lifesim_lib/const.py:1050 src/lifesim_lib/const.py:1089
 msgid "Apprentice Cameraman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1101
+#: src/lifesim_lib/const.py:1110
 msgid "Waiter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1164
+#: src/lifesim_lib/const.py:1173
 msgid "Talent Manager"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1165
+#: src/lifesim_lib/const.py:1174
 msgid "Talent Agent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1166 src/lifesim_lib/const.py:1317
+#: src/lifesim_lib/const.py:1175 src/lifesim_lib/const.py:1326
 msgid "Audition"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1167
+#: src/lifesim_lib/const.py:1176
 msgid "Extra"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1171
+#: src/lifesim_lib/const.py:1180
 msgid "if she could get a Carrot Top cast in a film, she could get you in one too"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1174 src/lifesim_lib/const.py:1325
+#: src/lifesim_lib/const.py:1183 src/lifesim_lib/const.py:1334
 msgid "he basically runs the industry and swears anyone would be lucky to work with him"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1180
+#: src/lifesim_lib/const.py:1189
 msgid "Movie Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1181
+#: src/lifesim_lib/const.py:1190
 msgid "Television Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1185
+#: src/lifesim_lib/const.py:1194
 msgid "Bit Role"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1186 src/lifesim_lib/const.py:1192
+#: src/lifesim_lib/const.py:1195 src/lifesim_lib/const.py:1201
 msgid "Lead Role"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1187
+#: src/lifesim_lib/const.py:1196
 msgid "Supporting Role"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1191
+#: src/lifesim_lib/const.py:1200
 msgid "Ensemble Role"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1193
+#: src/lifesim_lib/const.py:1202
 msgid "Recurring Role"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1194
+#: src/lifesim_lib/const.py:1203
 msgid "Regular Role"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1198
+#: src/lifesim_lib/const.py:1207
 msgid "A Businessman's daughter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1199
+#: src/lifesim_lib/const.py:1208
 msgid "A Bridesmaid"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1202
+#: src/lifesim_lib/const.py:1211
 msgid "A Businessman's son"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1203
+#: src/lifesim_lib/const.py:1212
 msgid "A Handyman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1207
+#: src/lifesim_lib/const.py:1216
 msgid "A&E Televison Network"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1208
+#: src/lifesim_lib/const.py:1217
 msgid "ABC Studios"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1209
+#: src/lifesim_lib/const.py:1218
 msgid "ACME Communications"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1210
+#: src/lifesim_lib/const.py:1219
 msgid "Alloy Entertainment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1211
+#: src/lifesim_lib/const.py:1220
 msgid "American Movie Classics"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1212
+#: src/lifesim_lib/const.py:1221
 msgid "Anonymous Content"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1213
+#: src/lifesim_lib/const.py:1222
 msgid "Bad Robot"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1214
+#: src/lifesim_lib/const.py:1223
 msgid "BBC America"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1215
+#: src/lifesim_lib/const.py:1224
 msgid "Beacon Pictures"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1216
+#: src/lifesim_lib/const.py:1225
 msgid "Bunim-Murray Productions"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1217
+#: src/lifesim_lib/const.py:1226
 msgid "CBS"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1218
+#: src/lifesim_lib/const.py:1227
 msgid "Defined Productions"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1219
+#: src/lifesim_lib/const.py:1228
 msgid "Dick Clark Productions"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1220
+#: src/lifesim_lib/const.py:1229
 msgid "eOne Television"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1221
+#: src/lifesim_lib/const.py:1230
 msgid "Eyeboogie, Inc."
 msgstr ""
 
-#: src/lifesim_lib/const.py:1222
+#: src/lifesim_lib/const.py:1231
 msgid "Filmation"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1223
+#: src/lifesim_lib/const.py:1232
 msgid "FremantleMedia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1224
+#: src/lifesim_lib/const.py:1233
 msgid "Global Broadcasting"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1225
+#: src/lifesim_lib/const.py:1234
 msgid "LIN TV Corporation"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1226
+#: src/lifesim_lib/const.py:1235
 msgid "Lions Gate Entertainment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1227
+#: src/lifesim_lib/const.py:1236
 msgid "Lorimar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1228
+#: src/lifesim_lib/const.py:1237
 msgid "Metro-Goldwyn-Mayer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1229
+#: src/lifesim_lib/const.py:1238
 msgid "Raycom Media"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1230
+#: src/lifesim_lib/const.py:1239
 msgid "Shine America"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1231
+#: src/lifesim_lib/const.py:1240
 msgid "Sony Pictures Television"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1232
+#: src/lifesim_lib/const.py:1241
 msgid "Tribune Entertainment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1233
+#: src/lifesim_lib/const.py:1242
 msgid "Universal Television"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1234
+#: src/lifesim_lib/const.py:1243
 msgid "Walt Disney Television"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1244
+#: src/lifesim_lib/const.py:1253
 msgid "Acquisition"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1245
+#: src/lifesim_lib/const.py:1254
 msgid "Startup"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1248
+#: src/lifesim_lib/const.py:1257
 msgid "Food Truck"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1249
+#: src/lifesim_lib/const.py:1258
 msgid "Gift Shop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1250
+#: src/lifesim_lib/const.py:1259
 msgid "Health Food Store"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1251
+#: src/lifesim_lib/const.py:1260
 msgid "Brewery"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1252
+#: src/lifesim_lib/const.py:1261
 msgid "Adult Toys"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1253
+#: src/lifesim_lib/const.py:1262
 msgid "Marijuana Dispensary"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1254
+#: src/lifesim_lib/const.py:1263
 msgid "Lingerie Boutique"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1255
+#: src/lifesim_lib/const.py:1264
 msgid "Novelty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1256
+#: src/lifesim_lib/const.py:1265
 msgid "Coffeehouse"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1257
+#: src/lifesim_lib/const.py:1266
 msgid "Beauty Supply"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1258
+#: src/lifesim_lib/const.py:1267
 msgid "Pet Supply"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1259
+#: src/lifesim_lib/const.py:1268
 msgid "Kitchenware"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1260
+#: src/lifesim_lib/const.py:1269
 msgid "Musical Instrument"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1261
+#: src/lifesim_lib/const.py:1270
 msgid "Jewellery"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1262
+#: src/lifesim_lib/const.py:1271
 msgid "Clothing Outlet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1263
+#: src/lifesim_lib/const.py:1272
 msgid "Sporting Goods"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1264
+#: src/lifesim_lib/const.py:1273
 msgid "Footware"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1265
+#: src/lifesim_lib/const.py:1274
 msgid "Distillery"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1266
+#: src/lifesim_lib/const.py:1275
 msgid "Dairy Farm"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1267
+#: src/lifesim_lib/const.py:1276
 msgid "Winery"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1268
+#: src/lifesim_lib/const.py:1277
 msgid "Consumer Electronics"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1270
+#: src/lifesim_lib/const.py:1279
 msgid "Pharmaceutical"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1271
+#: src/lifesim_lib/const.py:1280
 msgid "Semiconductor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1272
+#: src/lifesim_lib/const.py:1281
 msgid "Car Manufacturer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1278
+#: src/lifesim_lib/const.py:1287
 msgid "Biker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1279
+#: src/lifesim_lib/const.py:1288
 msgid "Irish Mob"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1280
+#: src/lifesim_lib/const.py:1289
 msgid "Latin Mafia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1281
+#: src/lifesim_lib/const.py:1290
 msgid "Mafia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1282
+#: src/lifesim_lib/const.py:1291
 msgid "Russian Mafia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1283
+#: src/lifesim_lib/const.py:1292
 msgid "Triad"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1284
+#: src/lifesim_lib/const.py:1293
 msgid "Yakuza"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1287
+#: src/lifesim_lib/const.py:1296
 msgid "Relay messages"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1288
+#: src/lifesim_lib/const.py:1297
 msgid "Chauffeur them around town"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1289
+#: src/lifesim_lib/const.py:1298
 msgid "Wait tables"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1290
+#: src/lifesim_lib/const.py:1299
 msgid "Offer to do favours"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1291
+#: src/lifesim_lib/const.py:1300
 msgid "Do yard work"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1292
+#: src/lifesim_lib/const.py:1301
 msgid "Hang out at their club"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1296
+#: src/lifesim_lib/const.py:1305
 msgid "Bandidos"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1297
+#: src/lifesim_lib/const.py:1306
 msgid "Hell's Angels"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1315
+#: src/lifesim_lib/const.py:1324
 msgid "Model Manager"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1316
+#: src/lifesim_lib/const.py:1325
 msgid "Model Agent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1318
+#: src/lifesim_lib/const.py:1327
 msgid "Freelance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1322
+#: src/lifesim_lib/const.py:1331
 msgid "if she could get Ugly Betty on the cover of Vogue, she could get you there too"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1332 src/lifesim_lib/const.py:1352
+#: src/lifesim_lib/const.py:1341 src/lifesim_lib/const.py:1361
 msgid "Artistic Nude"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1333
+#: src/lifesim_lib/const.py:1342
 msgid "Catwalk Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1334
+#: src/lifesim_lib/const.py:1343
 msgid "Commercial Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1335
+#: src/lifesim_lib/const.py:1344
 msgid "Editorial Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1336
+#: src/lifesim_lib/const.py:1345
 msgid "Fit Model Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1337
+#: src/lifesim_lib/const.py:1346
 msgid "Fitness Model Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1338
+#: src/lifesim_lib/const.py:1347
 msgid "Foot Model Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1339
+#: src/lifesim_lib/const.py:1348
 msgid "Glamour Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1340
+#: src/lifesim_lib/const.py:1349
 msgid "Hand Model Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1341
+#: src/lifesim_lib/const.py:1350
 msgid "High Fashion Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1342
+#: src/lifesim_lib/const.py:1351
 msgid "Lingerie Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1343
+#: src/lifesim_lib/const.py:1352
 msgid "Parts Model Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1344
+#: src/lifesim_lib/const.py:1353
 msgid "Print Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1345
+#: src/lifesim_lib/const.py:1354
 msgid "Promotional Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1346
+#: src/lifesim_lib/const.py:1355
 msgid "Sportswear Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1347
+#: src/lifesim_lib/const.py:1356
 msgid "Swimwear Roles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1353
+#: src/lifesim_lib/const.py:1362
 msgid "Catwalk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1354
+#: src/lifesim_lib/const.py:1363
 msgid "Commercial"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1355
+#: src/lifesim_lib/const.py:1364
 msgid "Editorial"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1356
+#: src/lifesim_lib/const.py:1365
 msgid "Fit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1357
+#: src/lifesim_lib/const.py:1366
 msgid "Fitness"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1358
+#: src/lifesim_lib/const.py:1367
 msgid "Foot"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1359
+#: src/lifesim_lib/const.py:1368
 msgid "Glamour"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1360
+#: src/lifesim_lib/const.py:1369
 msgid "Hand"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1361
+#: src/lifesim_lib/const.py:1370
 msgid "High"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1362
+#: src/lifesim_lib/const.py:1371
 msgid "Instagram"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1363 src/lifesim_lib/const.py:2245
+#: src/lifesim_lib/const.py:1372 src/lifesim_lib/const.py:2254
 msgid "Lingerie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1364
+#: src/lifesim_lib/const.py:1373
 msgid "OnlyFans"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1365
+#: src/lifesim_lib/const.py:1374
 msgid "Parts"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1366
+#: src/lifesim_lib/const.py:1375
 msgid "Print"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1367
+#: src/lifesim_lib/const.py:1376
 msgid "Promotional"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1368
+#: src/lifesim_lib/const.py:1377
 msgid "Sportswear"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1369 src/lifesim_lib/const.py:2249
+#: src/lifesim_lib/const.py:1378 src/lifesim_lib/const.py:2258
 msgid "Swimwear"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1375
+#: src/lifesim_lib/const.py:1384
 msgid "Life Modelling Class"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1376
+#: src/lifesim_lib/const.py:1385
 msgid "Painter's Studio"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1377
+#: src/lifesim_lib/const.py:1386
 msgid "Photographer's Studio"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1378
+#: src/lifesim_lib/const.py:1387
 msgid "Sculpturer's Studio"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1385
+#: src/lifesim_lib/const.py:1394
 msgid "A.P.C."
 msgstr ""
 
-#: src/lifesim_lib/const.py:1386
+#: src/lifesim_lib/const.py:1395
 msgid "Adidas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1387
+#: src/lifesim_lib/const.py:1396
 msgid "Aldo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1388
+#: src/lifesim_lib/const.py:1397
 msgid "Alexander McQueen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1389
+#: src/lifesim_lib/const.py:1398
 msgid "Alexander Wang"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1390
+#: src/lifesim_lib/const.py:1399
 msgid "Amélie Pichard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1391
+#: src/lifesim_lib/const.py:1400
 msgid "American Eagle Outfitters"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1392
+#: src/lifesim_lib/const.py:1401
 msgid "Armani"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1393
+#: src/lifesim_lib/const.py:1402
 msgid "Asics"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1394
+#: src/lifesim_lib/const.py:1403
 msgid "ASOS"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1395
+#: src/lifesim_lib/const.py:1404
 msgid "Audemars Piguet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1396
+#: src/lifesim_lib/const.py:1405
 msgid "Ba&sh"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1397
+#: src/lifesim_lib/const.py:1406
 msgid "Balenciaga"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1398
+#: src/lifesim_lib/const.py:1407
 msgid "Balmain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1399
+#: src/lifesim_lib/const.py:1408
 msgid "Banana Republic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1400
+#: src/lifesim_lib/const.py:1409
 msgid "Berluti"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1401
+#: src/lifesim_lib/const.py:1410
 msgid "Bogner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1402
+#: src/lifesim_lib/const.py:1411
 msgid "Bottega Veneta"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1403
+#: src/lifesim_lib/const.py:1412
 msgid "Breguet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1404
+#: src/lifesim_lib/const.py:1413
 msgid "Brioni"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1405
+#: src/lifesim_lib/const.py:1414
 msgid "Brunello Cucinelli"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1406
+#: src/lifesim_lib/const.py:1415
 msgid "Bulgari"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1407
+#: src/lifesim_lib/const.py:1416
 msgid "Burberry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1408
+#: src/lifesim_lib/const.py:1417
 msgid "C&A"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1409
+#: src/lifesim_lib/const.py:1418
 msgid "Calvin Klein"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1410
+#: src/lifesim_lib/const.py:1419
 msgid "Cartier"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1411
+#: src/lifesim_lib/const.py:1420
 msgid "Celine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1412
+#: src/lifesim_lib/const.py:1421
 msgid "Chanel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1413
+#: src/lifesim_lib/const.py:1422
 msgid "Chinti and Parker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1414
+#: src/lifesim_lib/const.py:1423
 msgid "Chloé"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1415
+#: src/lifesim_lib/const.py:1424
 msgid "Chopard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1416
+#: src/lifesim_lib/const.py:1425
 msgid "Chow Tai Fook"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1417
+#: src/lifesim_lib/const.py:1426
 msgid "Christian Dior"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1418
+#: src/lifesim_lib/const.py:1427
 msgid "Christian Louboutin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1419
+#: src/lifesim_lib/const.py:1428
 msgid "Christopher Kane"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1420
+#: src/lifesim_lib/const.py:1429
 msgid "Claudie Pierlot"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1421
+#: src/lifesim_lib/const.py:1430
 msgid "Clergerie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1422
+#: src/lifesim_lib/const.py:1431
 msgid "Coach"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1423
+#: src/lifesim_lib/const.py:1432
 msgid "Cole Haan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1424
+#: src/lifesim_lib/const.py:1433
 msgid "Comme Des Garçons"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1425
+#: src/lifesim_lib/const.py:1434
 msgid "DELPOZO"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1426
+#: src/lifesim_lib/const.py:1435
 msgid "Desigual"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1427 src/lifesim_lib/const.py:4084
+#: src/lifesim_lib/const.py:1436 src/lifesim_lib/const.py:4093
 msgid "Diesel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1428
+#: src/lifesim_lib/const.py:1437
 msgid "Dior"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1429
+#: src/lifesim_lib/const.py:1438
 msgid "DKNY"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1430
+#: src/lifesim_lib/const.py:1439
 msgid "Dolce & Gabbana"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1431
+#: src/lifesim_lib/const.py:1440
 msgid "Elie Saab"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1432
+#: src/lifesim_lib/const.py:1441
 msgid "Elie Tahari"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1433
+#: src/lifesim_lib/const.py:1442
 msgid "Emilio Pucci"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1434
+#: src/lifesim_lib/const.py:1443
 msgid "Eres"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1435
+#: src/lifesim_lib/const.py:1444
 msgid "Ermenegildo Zegna"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1436
+#: src/lifesim_lib/const.py:1445
 msgid "ESCADA"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1437
+#: src/lifesim_lib/const.py:1446
 msgid "Faith Connexion"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1438
+#: src/lifesim_lib/const.py:1447
 msgid "Fendi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1439
+#: src/lifesim_lib/const.py:1448
 msgid "Fenty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1440
+#: src/lifesim_lib/const.py:1449
 msgid "Fila"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1441
+#: src/lifesim_lib/const.py:1450
 msgid "Foot Locker Inc."
 msgstr ""
 
-#: src/lifesim_lib/const.py:1442
+#: src/lifesim_lib/const.py:1451
 msgid "Forever 21"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1443
+#: src/lifesim_lib/const.py:1452
 msgid "Fossil"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1444
+#: src/lifesim_lib/const.py:1453
 msgid "Franck Muller"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1445
+#: src/lifesim_lib/const.py:1454
 msgid "Furla"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1446
+#: src/lifesim_lib/const.py:1455
 msgid "G-star"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1447
+#: src/lifesim_lib/const.py:1456
 msgid "GAP"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1448
+#: src/lifesim_lib/const.py:1457
 msgid "Giorgio Armani"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1449
+#: src/lifesim_lib/const.py:1458
 msgid "Givenchy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1450
+#: src/lifesim_lib/const.py:1459
 msgid "Goyard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1451
+#: src/lifesim_lib/const.py:1460
 msgid "Gucci"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1452
+#: src/lifesim_lib/const.py:1461
 msgid "H&M"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1453
+#: src/lifesim_lib/const.py:1462
 msgid "Hermès"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1454
+#: src/lifesim_lib/const.py:1463
 msgid "Hugo Boss"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1455
+#: src/lifesim_lib/const.py:1464
 msgid "Iro"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1456
+#: src/lifesim_lib/const.py:1465
 msgid "Isabel Marant"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1457
+#: src/lifesim_lib/const.py:1466
 msgid "IWC Schaffhausen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1458
+#: src/lifesim_lib/const.py:1467
 msgid "Jacquemus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1459
+#: src/lifesim_lib/const.py:1468
 msgid "Jaeger-Le Coultre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1460
+#: src/lifesim_lib/const.py:1469
 msgid "Jérôme Dreyfuss"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1461
+#: src/lifesim_lib/const.py:1470
 msgid "Jil Sander"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1462
+#: src/lifesim_lib/const.py:1471
 msgid "Jimmy Choo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1463
+#: src/lifesim_lib/const.py:1472
 msgid "Kate Spade"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1464
+#: src/lifesim_lib/const.py:1473
 msgid "Kenzo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1465
+#: src/lifesim_lib/const.py:1474
 msgid "Lacoste"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1466
+#: src/lifesim_lib/const.py:1475
 msgid "Lanvin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1467
+#: src/lifesim_lib/const.py:1476
 msgid "Lao Feng Xiang"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1468
+#: src/lifesim_lib/const.py:1477
 msgid "Lemaire"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1469
+#: src/lifesim_lib/const.py:1478
 msgid "Levi’s"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1470
+#: src/lifesim_lib/const.py:1479
 msgid "Loewe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1471
+#: src/lifesim_lib/const.py:1480
 msgid "Longchamp"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1472
+#: src/lifesim_lib/const.py:1481
 msgid "Longines"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1473
+#: src/lifesim_lib/const.py:1482
 msgid "Loro Piana"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1474
+#: src/lifesim_lib/const.py:1483
 msgid "Louis Vuitton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1475
+#: src/lifesim_lib/const.py:1484
 msgid "Lululemon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1476
+#: src/lifesim_lib/const.py:1485
 msgid "Macy’s"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1477
+#: src/lifesim_lib/const.py:1486
 msgid "Maison Michel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1478
+#: src/lifesim_lib/const.py:1487
 msgid "Manolo Blahnik"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1479
+#: src/lifesim_lib/const.py:1488
 msgid "Marc Jacobs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1480
+#: src/lifesim_lib/const.py:1489
 msgid "Marcelo Burlon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1481
+#: src/lifesim_lib/const.py:1490
 msgid "Margaret Howell"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1482
+#: src/lifesim_lib/const.py:1491
 msgid "Marni"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1483
+#: src/lifesim_lib/const.py:1492
 msgid "Max Mara"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1484
+#: src/lifesim_lib/const.py:1493
 msgid "MCM"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1485 src/lifesim_lib/const.py:4398
+#: src/lifesim_lib/const.py:1494 src/lifesim_lib/const.py:4407
 msgid "Michael Kors"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1486
+#: src/lifesim_lib/const.py:1495
 msgid "Missoni"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1487
+#: src/lifesim_lib/const.py:1496
 msgid "Miu Miu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1488
+#: src/lifesim_lib/const.py:1497
 msgid "Moncler"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1489
+#: src/lifesim_lib/const.py:1498
 msgid "Moschino"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1490
+#: src/lifesim_lib/const.py:1499
 msgid "Moynat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1491
+#: src/lifesim_lib/const.py:1500
 msgid "Net-a-Porter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1492
+#: src/lifesim_lib/const.py:1501
 msgid "New Balance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1493
+#: src/lifesim_lib/const.py:1502
 msgid "New Look"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1494
+#: src/lifesim_lib/const.py:1503
 msgid "Next"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1495
+#: src/lifesim_lib/const.py:1504
 msgid "Nicholas Kirkwood"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1496
+#: src/lifesim_lib/const.py:1505
 msgid "Nike"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1497
+#: src/lifesim_lib/const.py:1506
 msgid "Nine West"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1498
+#: src/lifesim_lib/const.py:1507
 msgid "Nordstrom"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1499 src/lifesim_lib/const.py:4109
+#: src/lifesim_lib/const.py:1508 src/lifesim_lib/const.py:4118
 msgid "Oakley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1500
+#: src/lifesim_lib/const.py:1509
 msgid "Off White"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1501
+#: src/lifesim_lib/const.py:1510
 msgid "Old Navy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1502
+#: src/lifesim_lib/const.py:1511
 msgid "Omega"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1503
+#: src/lifesim_lib/const.py:1512
 msgid "Oscar de la Renta"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1504
+#: src/lifesim_lib/const.py:1513
 msgid "Paco Rabanne"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1505
+#: src/lifesim_lib/const.py:1514
 msgid "Patagonia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1506
+#: src/lifesim_lib/const.py:1515
 msgid "Patek Philippe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1507
+#: src/lifesim_lib/const.py:1516
 msgid "Patou"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1508
+#: src/lifesim_lib/const.py:1517
 msgid "Paul Smith"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1509
+#: src/lifesim_lib/const.py:1518
 msgid "Paul Stuart"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1510
+#: src/lifesim_lib/const.py:1519
 msgid "Pink Shirtmaker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1511
+#: src/lifesim_lib/const.py:1520
 msgid "Prada"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1512
+#: src/lifesim_lib/const.py:1521
 msgid "Primark"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1513
+#: src/lifesim_lib/const.py:1522
 msgid "Puma"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1514
+#: src/lifesim_lib/const.py:1523
 msgid "Ralph Lauren"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1515
+#: src/lifesim_lib/const.py:1524
 msgid "Ray-Ban"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1516
+#: src/lifesim_lib/const.py:1525
 msgid "Rimowa"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1517
+#: src/lifesim_lib/const.py:1526
 msgid "Rolex"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1518
+#: src/lifesim_lib/const.py:1527
 msgid "Rouje"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1519
+#: src/lifesim_lib/const.py:1528
 msgid "Salvatore Ferragamo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1520
+#: src/lifesim_lib/const.py:1529
 msgid "Sisley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1521
+#: src/lifesim_lib/const.py:1530
 msgid "Skechers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1522
+#: src/lifesim_lib/const.py:1531
 msgid "Stella McCartney"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1523
+#: src/lifesim_lib/const.py:1532
 msgid "Steve Madden"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1524
+#: src/lifesim_lib/const.py:1533
 msgid "Stuart Weitzman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1525
+#: src/lifesim_lib/const.py:1534
 msgid "Sunnei"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1526
+#: src/lifesim_lib/const.py:1535
 msgid "Swarovski"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1527
+#: src/lifesim_lib/const.py:1536
 msgid "Swatch"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1528
+#: src/lifesim_lib/const.py:1537
 msgid "Tag Heuer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1529
+#: src/lifesim_lib/const.py:1538
 msgid "Ted Baker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1530
+#: src/lifesim_lib/const.py:1539
 msgid "Temperley London"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1531
+#: src/lifesim_lib/const.py:1540
 msgid "The Kooples"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1532
+#: src/lifesim_lib/const.py:1541
 msgid "The North Face"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1533
+#: src/lifesim_lib/const.py:1542
 msgid "Thom Browne"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1534
+#: src/lifesim_lib/const.py:1543
 msgid "Tiffany & Co."
 msgstr ""
 
-#: src/lifesim_lib/const.py:1535
+#: src/lifesim_lib/const.py:1544
 msgid "Tissot"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1536
+#: src/lifesim_lib/const.py:1545
 msgid "TJ Maxx"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1537
+#: src/lifesim_lib/const.py:1546
 msgid "TOD’s"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1538 src/lifesim_lib/const.py:4399
+#: src/lifesim_lib/const.py:1547 src/lifesim_lib/const.py:4408
 msgid "Tom Ford"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1539
+#: src/lifesim_lib/const.py:1548
 msgid "Tommy Hilfiger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1540
+#: src/lifesim_lib/const.py:1549
 msgid "Topshop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1541
+#: src/lifesim_lib/const.py:1550
 msgid "Tory Burch"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1542
+#: src/lifesim_lib/const.py:1551
 msgid "Under Armour"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1543
+#: src/lifesim_lib/const.py:1552
 msgid "UNIQLO"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1544
+#: src/lifesim_lib/const.py:1553
 msgid "Urban Outfitters"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1545
+#: src/lifesim_lib/const.py:1554
 msgid "Vacheron Constantin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1546
+#: src/lifesim_lib/const.py:1555
 msgid "Valentino"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1547
+#: src/lifesim_lib/const.py:1556
 msgid "Vera Wang"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1548
+#: src/lifesim_lib/const.py:1557
 msgid "Victoria’s Secret"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1549
+#: src/lifesim_lib/const.py:1558
 msgid "Vivienne Westwood"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1550
+#: src/lifesim_lib/const.py:1559
 msgid "Yohji Yamamoto"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1551
+#: src/lifesim_lib/const.py:1560
 msgid "Yves Saint Laurent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1552
+#: src/lifesim_lib/const.py:1561
 msgid "Zalando"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1553
+#: src/lifesim_lib/const.py:1562
 msgid "Zara"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1557
+#: src/lifesim_lib/const.py:1566
 msgid "London"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1558
+#: src/lifesim_lib/const.py:1567
 msgid "Milan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1559
+#: src/lifesim_lib/const.py:1568
 msgid "New York"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1560
+#: src/lifesim_lib/const.py:1569
 msgid "Paris"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1563
+#: src/lifesim_lib/const.py:1572
 msgid "Australian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1564
+#: src/lifesim_lib/const.py:1573
 msgid "Berlin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1566
+#: src/lifesim_lib/const.py:1575
 msgid "Seoul"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1567
+#: src/lifesim_lib/const.py:1576
 msgid "Shanghai"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1568
+#: src/lifesim_lib/const.py:1577
 msgid "Tokyo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1569
+#: src/lifesim_lib/const.py:1578
 msgid "Venice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1572
+#: src/lifesim_lib/const.py:1581
 msgid "Accra"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1573
+#: src/lifesim_lib/const.py:1582
 msgid "Alta Roma"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1574
+#: src/lifesim_lib/const.py:1583
 msgid "Arab"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1575
+#: src/lifesim_lib/const.py:1584
 msgid "Bangalore"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1576
+#: src/lifesim_lib/const.py:1585
 msgid "Barcelona"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1577
+#: src/lifesim_lib/const.py:1586
 msgid "Bulgarian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1578
+#: src/lifesim_lib/const.py:1587
 msgid "Colombiamoda"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1579
+#: src/lifesim_lib/const.py:1588
 msgid "Columbus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1580
+#: src/lifesim_lib/const.py:1589
 msgid "Copenhagen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1581
+#: src/lifesim_lib/const.py:1590
 msgid "Dubai International"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1583
+#: src/lifesim_lib/const.py:1592
 msgid "Frankfurt"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1584
+#: src/lifesim_lib/const.py:1593
 msgid "Hong Kong"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1585
+#: src/lifesim_lib/const.py:1594
 msgid "Lagos"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1586
+#: src/lifesim_lib/const.py:1595
 msgid "MTC Windhoek"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1589
+#: src/lifesim_lib/const.py:1598
 msgid "Port of Spain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1590
+#: src/lifesim_lib/const.py:1599
 msgid "Portland"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1591
+#: src/lifesim_lib/const.py:1600
 msgid "Stockholm"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1592
+#: src/lifesim_lib/const.py:1601
 msgid "Swahili"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1593
+#: src/lifesim_lib/const.py:1602
 msgid "Ukrainian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1600
+#: src/lifesim_lib/const.py:1609
 msgid "Band"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1601
+#: src/lifesim_lib/const.py:1610
 msgid "Solo Artist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1605
+#: src/lifesim_lib/const.py:1614
 msgid "Bassist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1606
+#: src/lifesim_lib/const.py:1615
 msgid "Drummer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1607 src/lifesim_lib/const.py:1614
+#: src/lifesim_lib/const.py:1616 src/lifesim_lib/const.py:1623
 msgid "Guitarist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1608
+#: src/lifesim_lib/const.py:1617
 msgid "Keyboardist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1609 src/lifesim_lib/const.py:1617
+#: src/lifesim_lib/const.py:1618 src/lifesim_lib/const.py:1626
 msgid "Singer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1613
+#: src/lifesim_lib/const.py:1622
 msgid "Cellist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1615
+#: src/lifesim_lib/const.py:1624
 msgid "Pianist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1616
+#: src/lifesim_lib/const.py:1625
 msgid "Saxophonist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1618
+#: src/lifesim_lib/const.py:1627
 msgid "Violinist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1621
+#: src/lifesim_lib/const.py:1630
 msgid "Atrium Records"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1622
+#: src/lifesim_lib/const.py:1631
 msgid "Falcon Records"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1623
+#: src/lifesim_lib/const.py:1632
 msgid "United Beats"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1633
+#: src/lifesim_lib/const.py:1642
 msgid "School Board Director"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1634
+#: src/lifesim_lib/const.py:1643
 msgid "Mayor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1635
+#: src/lifesim_lib/const.py:1644
 msgid "Governor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1639
+#: src/lifesim_lib/const.py:1648
 msgid "Economy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1640
+#: src/lifesim_lib/const.py:1649
 msgid "Education"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1641
+#: src/lifesim_lib/const.py:1650
 msgid "Environment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1642
+#: src/lifesim_lib/const.py:1651
 msgid "Social Issues"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1648
+#: src/lifesim_lib/const.py:1657
 msgid "American Football"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1649
+#: src/lifesim_lib/const.py:1658
 msgid "Association Football"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1650
+#: src/lifesim_lib/const.py:1659
 msgid "Australian Rules Football"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1651
+#: src/lifesim_lib/const.py:1660
 msgid "Baseball"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1652
+#: src/lifesim_lib/const.py:1661
 msgid "Basketball"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1653
+#: src/lifesim_lib/const.py:1662
 msgid "Boxing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1654
+#: src/lifesim_lib/const.py:1663
 msgid "Canadian Football"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1655
+#: src/lifesim_lib/const.py:1664
 msgid "Cricket"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1656
+#: src/lifesim_lib/const.py:1665
 msgid "Gaelic Football"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1657
+#: src/lifesim_lib/const.py:1666
 msgid "Golf"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1658
+#: src/lifesim_lib/const.py:1667
 msgid "Ice Hockey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1659
+#: src/lifesim_lib/const.py:1668
 msgid "Rugby League"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1660
+#: src/lifesim_lib/const.py:1669
 msgid "Rugby Union"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1661
+#: src/lifesim_lib/const.py:1670
 msgid "Surfing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1662
+#: src/lifesim_lib/const.py:1671
 msgid "Tennis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1663
+#: src/lifesim_lib/const.py:1672
 msgid "Volleyball"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1668
+#: src/lifesim_lib/const.py:1677
 msgid "Arizona Cardinals"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1669
+#: src/lifesim_lib/const.py:1678
 msgid "Atlanta Falcons"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1670
+#: src/lifesim_lib/const.py:1679
 msgid "Carolina Panthers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1671
+#: src/lifesim_lib/const.py:1680
 msgid "Chicago Bears"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1672
+#: src/lifesim_lib/const.py:1681
 msgid "Dallas Cowboys"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1673
+#: src/lifesim_lib/const.py:1682
 msgid "Detroit Lions"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1674
+#: src/lifesim_lib/const.py:1683
 msgid "Green Bay Packers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1675
+#: src/lifesim_lib/const.py:1684
 msgid "Los Angeles Rams"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1676
+#: src/lifesim_lib/const.py:1685
 msgid "Minnesota Vikings"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1677
+#: src/lifesim_lib/const.py:1686
 msgid "New Orleans Saints"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1678
+#: src/lifesim_lib/const.py:1687
 msgid "New York Giants"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1679
+#: src/lifesim_lib/const.py:1688
 msgid "Philadelphia Eagles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1680
+#: src/lifesim_lib/const.py:1689
 msgid "San Francisco 49ers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1681
+#: src/lifesim_lib/const.py:1690
 msgid "Seattle Seahawks"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1682
+#: src/lifesim_lib/const.py:1691
 msgid "Tampa Bay Buccaneers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1683
+#: src/lifesim_lib/const.py:1692
 msgid "Washington Commanders"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1686
+#: src/lifesim_lib/const.py:1695
 msgid "Baltimore Ravens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1687
+#: src/lifesim_lib/const.py:1696
 msgid "Buffalo Bills"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1688
+#: src/lifesim_lib/const.py:1697
 msgid "Cincinnati Bengals"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1689
+#: src/lifesim_lib/const.py:1698
 msgid "Cleveland Browns"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1690
+#: src/lifesim_lib/const.py:1699
 msgid "Denver Broncos"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1691
+#: src/lifesim_lib/const.py:1700
 msgid "Houston Texans"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1692
+#: src/lifesim_lib/const.py:1701
 msgid "Indianapolis Colts"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1693
+#: src/lifesim_lib/const.py:1702
 msgid "Jacksonville Jaguars"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1694
+#: src/lifesim_lib/const.py:1703
 msgid "Kansas City Chiefs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1695
+#: src/lifesim_lib/const.py:1704
 msgid "Las Vegas Raiders"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1696
+#: src/lifesim_lib/const.py:1705
 msgid "Los Angeles Chargers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1697
+#: src/lifesim_lib/const.py:1706
 msgid "Miami Dolphins"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1698
+#: src/lifesim_lib/const.py:1707
 msgid "New England Patriots"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1699
+#: src/lifesim_lib/const.py:1708
 msgid "New York Jets"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1700
+#: src/lifesim_lib/const.py:1709
 msgid "Pittsburgh Steelers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1701
+#: src/lifesim_lib/const.py:1710
 msgid "Tennessee Titans"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1705
+#: src/lifesim_lib/const.py:1714
 msgid "Safety"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1706
+#: src/lifesim_lib/const.py:1715
 msgid "Cornerback"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1707
+#: src/lifesim_lib/const.py:1716
 msgid "Outside Linebacker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1708
+#: src/lifesim_lib/const.py:1717
 msgid "Middle Linebacker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1709
+#: src/lifesim_lib/const.py:1718
 msgid "End"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1710
+#: src/lifesim_lib/const.py:1719
 msgid "Defensive Tackle"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1711 src/lifesim_lib/const.py:1717
+#: src/lifesim_lib/const.py:1720 src/lifesim_lib/const.py:1726
 msgid "Wide Receiver"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1712
+#: src/lifesim_lib/const.py:1721
 msgid "Offensive Tackle"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1713
+#: src/lifesim_lib/const.py:1722
 msgid "Offensive Guard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1714 src/lifesim_lib/const.py:1828
+#: src/lifesim_lib/const.py:1723 src/lifesim_lib/const.py:1837
 msgid "Center"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1715
+#: src/lifesim_lib/const.py:1724
 msgid "Tight End"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1716
+#: src/lifesim_lib/const.py:1725
 msgid "Quarterback"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1718
+#: src/lifesim_lib/const.py:1727
 msgid "Fullback / Running Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1719
+#: src/lifesim_lib/const.py:1728
 msgid "Halfback / Running Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1724
+#: src/lifesim_lib/const.py:1733
 msgid "Arsenal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1725
+#: src/lifesim_lib/const.py:1734
 msgid "Aston Villa"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1726
+#: src/lifesim_lib/const.py:1735
 msgid "Bournemouth"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1727
+#: src/lifesim_lib/const.py:1736
 msgid "Brentford"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1728
+#: src/lifesim_lib/const.py:1737
 msgid "Brighton & Hove Albion"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1729
+#: src/lifesim_lib/const.py:1738
 msgid "Chelsea"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1730
+#: src/lifesim_lib/const.py:1739
 msgid "Crystal Palace"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1731
+#: src/lifesim_lib/const.py:1740
 msgid "Everton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1732
+#: src/lifesim_lib/const.py:1741
 msgid "Fulham"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1733
+#: src/lifesim_lib/const.py:1742
 msgid "Leeds United"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1734
+#: src/lifesim_lib/const.py:1743
 msgid "Leicester City"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1735
+#: src/lifesim_lib/const.py:1744
 msgid "Liverpool"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1736
+#: src/lifesim_lib/const.py:1745
 msgid "Manchester City"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1737
+#: src/lifesim_lib/const.py:1746
 msgid "Manchester United"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1738
+#: src/lifesim_lib/const.py:1747
 msgid "Newcastle United"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1739
+#: src/lifesim_lib/const.py:1748
 msgid "Nottingham Forest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1740
+#: src/lifesim_lib/const.py:1749
 msgid "Southampton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1741
+#: src/lifesim_lib/const.py:1750
 msgid "Tottenham Hotspur"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1742
+#: src/lifesim_lib/const.py:1751
 msgid "West Ham United"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1743
+#: src/lifesim_lib/const.py:1752
 msgid "Wolverhampton Wanderers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1747
+#: src/lifesim_lib/const.py:1756
 msgid "Goalkeeper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1748
+#: src/lifesim_lib/const.py:1757
 msgid "Full-Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1749
+#: src/lifesim_lib/const.py:1758
 msgid "Centre-Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1750
+#: src/lifesim_lib/const.py:1759
 msgid "Sweeper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1751
+#: src/lifesim_lib/const.py:1760
 msgid "Wing-Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1752
+#: src/lifesim_lib/const.py:1761
 msgid "Defensive Midfielder"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1753
+#: src/lifesim_lib/const.py:1762
 msgid "Central Midfielder"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1754
+#: src/lifesim_lib/const.py:1763
 msgid "Attacking Midfielder"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1755
+#: src/lifesim_lib/const.py:1764
 msgid "Winger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1756
+#: src/lifesim_lib/const.py:1765
 msgid "Forward"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1757
+#: src/lifesim_lib/const.py:1766
 msgid "Striker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1762
+#: src/lifesim_lib/const.py:1771
 msgid "Adelaide Crows"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1763
+#: src/lifesim_lib/const.py:1772
 msgid "Brisbane Lions"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1764
+#: src/lifesim_lib/const.py:1773
 msgid "Carlton Blues"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1765
+#: src/lifesim_lib/const.py:1774
 msgid "Collingwood Magpies"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1766
+#: src/lifesim_lib/const.py:1775
 msgid "Essendon Bombers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1767
+#: src/lifesim_lib/const.py:1776
 msgid "Fremantle Dockers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1768
+#: src/lifesim_lib/const.py:1777
 msgid "Geelong Cats"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1769
+#: src/lifesim_lib/const.py:1778
 msgid "Gold Coast Suns"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1770
+#: src/lifesim_lib/const.py:1779
 msgid "Greater Western Sydney Giants"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1771
+#: src/lifesim_lib/const.py:1780
 msgid "Hawthorn Hawks"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1772
+#: src/lifesim_lib/const.py:1781
 msgid "Melbourne Demons"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1773
+#: src/lifesim_lib/const.py:1782
 msgid "North Melbourne Kangaroos"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1774
+#: src/lifesim_lib/const.py:1783
 msgid "Port Adelaide Power"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1775
+#: src/lifesim_lib/const.py:1784
 msgid "Richmond Tigers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1776
+#: src/lifesim_lib/const.py:1785
 msgid "St Kilda Saints"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1777
+#: src/lifesim_lib/const.py:1786
 msgid "Sydney Swans"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1778
+#: src/lifesim_lib/const.py:1787
 msgid "West Coast Eagles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1779
+#: src/lifesim_lib/const.py:1788
 msgid "Western Bulldogs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1783
+#: src/lifesim_lib/const.py:1792
 msgid "Left Forward Pocket"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1784
+#: src/lifesim_lib/const.py:1793
 msgid "Full Forward"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1785
+#: src/lifesim_lib/const.py:1794
 msgid "Right Forward Pocket"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1786
+#: src/lifesim_lib/const.py:1795
 msgid "Left Forward Flank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1787
+#: src/lifesim_lib/const.py:1796
 msgid "Centre Half Forward"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1788
+#: src/lifesim_lib/const.py:1797
 msgid "Right Forward Flank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1789
+#: src/lifesim_lib/const.py:1798
 msgid "Left Wing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1790
+#: src/lifesim_lib/const.py:1799
 msgid "Centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1791
+#: src/lifesim_lib/const.py:1800
 msgid "Ruck Rover"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1792
+#: src/lifesim_lib/const.py:1801
 msgid "Ruck"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1793
+#: src/lifesim_lib/const.py:1802
 msgid "Rover"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1794
+#: src/lifesim_lib/const.py:1803
 msgid "Right Wing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1795
+#: src/lifesim_lib/const.py:1804
 msgid "Left Back Flank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1796
+#: src/lifesim_lib/const.py:1805
 msgid "Centre Half Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1797
+#: src/lifesim_lib/const.py:1806
 msgid "Right Back Flank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1798
+#: src/lifesim_lib/const.py:1807
 msgid "Left Back Pocket"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1799
+#: src/lifesim_lib/const.py:1808
 msgid "Full Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1800
+#: src/lifesim_lib/const.py:1809
 msgid "Right Back Pocket"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1807
+#: src/lifesim_lib/const.py:1816
 msgid "Pitcher"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1808
+#: src/lifesim_lib/const.py:1817
 msgid "Catcher"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1809
+#: src/lifesim_lib/const.py:1818
 msgid "First Base"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1810
+#: src/lifesim_lib/const.py:1819
 msgid "Second Base"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1811
+#: src/lifesim_lib/const.py:1820
 msgid "Third Base"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1812
+#: src/lifesim_lib/const.py:1821
 msgid "Shortstop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1813
+#: src/lifesim_lib/const.py:1822
 msgid "Left Field"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1814
+#: src/lifesim_lib/const.py:1823
 msgid "Center Field"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1815
+#: src/lifesim_lib/const.py:1824
 msgid "Right Field"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1816
+#: src/lifesim_lib/const.py:1825
 msgid "Outfield"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1817
+#: src/lifesim_lib/const.py:1826
 msgid "Designated Hitter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1824
+#: src/lifesim_lib/const.py:1833
 msgid "Point Guard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1825
+#: src/lifesim_lib/const.py:1834
 msgid "Shooting Guard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1826
+#: src/lifesim_lib/const.py:1835
 msgid "Small Forward"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1827
+#: src/lifesim_lib/const.py:1836
 msgid "Power Forward"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1873
+#: src/lifesim_lib/const.py:1882
 msgid "Filipe Toledo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1874
+#: src/lifesim_lib/const.py:1883
 msgid "Italo Ferreira"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1875
+#: src/lifesim_lib/const.py:1884
 msgid "Jack Robinson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1876
+#: src/lifesim_lib/const.py:1885
 msgid "Ethan Ewing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1877
+#: src/lifesim_lib/const.py:1886
 msgid "Kanoa Igarashi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1878
+#: src/lifesim_lib/const.py:1887
 msgid "Miguel Pupo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1879
+#: src/lifesim_lib/const.py:1888
 msgid "Griffin Colapinto"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1880
+#: src/lifesim_lib/const.py:1889
 msgid "Caio Ibelli"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1881
+#: src/lifesim_lib/const.py:1890
 msgid "Connor O'Leary"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1882
+#: src/lifesim_lib/const.py:1891
 msgid "Callum Robson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1883
+#: src/lifesim_lib/const.py:1892
 msgid "Samuel Pupo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1884
+#: src/lifesim_lib/const.py:1893
 msgid "John John Florence"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1885
+#: src/lifesim_lib/const.py:1894
 msgid "Matthew McGillivray"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1886
+#: src/lifesim_lib/const.py:1895
 msgid "Jordy Smith"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1887
+#: src/lifesim_lib/const.py:1896
 msgid "Kelly Slater"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1888
+#: src/lifesim_lib/const.py:1897
 msgid "Barron Mamiya"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1889
+#: src/lifesim_lib/const.py:1898
 msgid "Nat Young"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1890
+#: src/lifesim_lib/const.py:1899
 msgid "Jake Marshall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1891
+#: src/lifesim_lib/const.py:1900
 msgid "Yago Dora"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1892
+#: src/lifesim_lib/const.py:1901
 msgid "Kolohe Andino"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1893
+#: src/lifesim_lib/const.py:1902
 msgid "Jadson Andre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1894
+#: src/lifesim_lib/const.py:1903
 msgid "Seth Moniz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1895
+#: src/lifesim_lib/const.py:1904
 msgid "Jackson Baker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1896
+#: src/lifesim_lib/const.py:1905
 msgid "Gabriel Medina"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1903
+#: src/lifesim_lib/const.py:1912
 msgid "Stephanie Gilmore"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1904
+#: src/lifesim_lib/const.py:1913
 msgid "Carissa Moore"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1905
+#: src/lifesim_lib/const.py:1914
 msgid "Johanne Defay"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1906
+#: src/lifesim_lib/const.py:1915
 msgid "Tatiana Weston-Webb"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1907
+#: src/lifesim_lib/const.py:1916
 msgid "Brisa Hennessy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1908
+#: src/lifesim_lib/const.py:1917
 msgid "Lakey Peterson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1909
+#: src/lifesim_lib/const.py:1918
 msgid "Courtney Conlogue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1910
+#: src/lifesim_lib/const.py:1919
 msgid "Tyler Wright"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1911
+#: src/lifesim_lib/const.py:1920
 msgid "Gabriela Bryan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1912
+#: src/lifesim_lib/const.py:1921
 msgid "Isabella Nichols"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1913
+#: src/lifesim_lib/const.py:1922
 msgid "Caroline Marks"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1914
+#: src/lifesim_lib/const.py:1923
 msgid "Sally Fitzgibbons"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1923
+#: src/lifesim_lib/const.py:1932
 msgid "Carlos Alcaraz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1924
+#: src/lifesim_lib/const.py:1933
 msgid "Rafael Nadal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1925
+#: src/lifesim_lib/const.py:1934
 msgid "Casper Ruud"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1926
+#: src/lifesim_lib/const.py:1935
 msgid "Daniil Medvedev"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1927
+#: src/lifesim_lib/const.py:1936
 msgid "Stefanos Tsitsipas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1928
+#: src/lifesim_lib/const.py:1937
 msgid "Alexander Zverev"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1929
+#: src/lifesim_lib/const.py:1938
 msgid "Novak Djokovic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1930
+#: src/lifesim_lib/const.py:1939
 msgid "Andrey Rublev"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1931
+#: src/lifesim_lib/const.py:1940
 msgid "Felix Auger-Aliassime"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1932
+#: src/lifesim_lib/const.py:1941
 msgid "Taylor Fritz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1933
+#: src/lifesim_lib/const.py:1942
 msgid "Hubert Hurkacz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1934
+#: src/lifesim_lib/const.py:1943
 msgid "Jannik Sinner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1935
+#: src/lifesim_lib/const.py:1944
 msgid "Cameron Norrie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1936
+#: src/lifesim_lib/const.py:1945
 msgid "Matteo Berrettini"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1937
+#: src/lifesim_lib/const.py:1946
 msgid "Pablo Carreno Busta"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1938
+#: src/lifesim_lib/const.py:1947
 msgid "Marin Čilić"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1939
+#: src/lifesim_lib/const.py:1948
 msgid "Frances Tiafoe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1940
+#: src/lifesim_lib/const.py:1949
 msgid "Karen Khachanov"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1941
+#: src/lifesim_lib/const.py:1950
 msgid "Denis Shapovalov"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1942
+#: src/lifesim_lib/const.py:1951
 msgid "Nick Kyrgios"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1943
+#: src/lifesim_lib/const.py:1952
 msgid "Diego Schwartzman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1944
+#: src/lifesim_lib/const.py:1953
 msgid "Roberto Bautista Agut"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1945
+#: src/lifesim_lib/const.py:1954
 msgid "Lorenzo Musetti"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1946
+#: src/lifesim_lib/const.py:1955
 msgid "Alex De Minaur"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1947
+#: src/lifesim_lib/const.py:1956
 msgid "Holger Rune"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1948
+#: src/lifesim_lib/const.py:1957
 msgid "Daniel Evans"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1949
+#: src/lifesim_lib/const.py:1958
 msgid "Borna Coric"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1950
+#: src/lifesim_lib/const.py:1959
 msgid "Miomir Kecmanovic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1951
+#: src/lifesim_lib/const.py:1960
 msgid "Francisco Cerundolo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1952
+#: src/lifesim_lib/const.py:1961
 msgid "Tommy Paul"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1953
+#: src/lifesim_lib/const.py:1962
 msgid "Alejandro Davidovich Fokina"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1954
+#: src/lifesim_lib/const.py:1963
 msgid "Grigor Dimitrov"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1955
+#: src/lifesim_lib/const.py:1964
 msgid "Sebastian Korda"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1956
+#: src/lifesim_lib/const.py:1965
 msgid "Maxime Cressy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1957
+#: src/lifesim_lib/const.py:1966
 msgid "Botic Van De Zandschulp"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1958
+#: src/lifesim_lib/const.py:1967
 msgid "Reilly Opelka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1959
+#: src/lifesim_lib/const.py:1968
 msgid "Yoshihito Nishioka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1960
+#: src/lifesim_lib/const.py:1969
 msgid "Alexander Bublik"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1961
+#: src/lifesim_lib/const.py:1970
 msgid "Sebastian Baez"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1962
+#: src/lifesim_lib/const.py:1971
 msgid "Albert Ramos-Vinolas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1963
+#: src/lifesim_lib/const.py:1972
 msgid "Gael Monfils"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1964
+#: src/lifesim_lib/const.py:1973
 msgid "Adrian Mannarino"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1965
+#: src/lifesim_lib/const.py:1974
 msgid "Emil Ruusuvuori"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1966
+#: src/lifesim_lib/const.py:1975
 msgid "Brandon Nakashima"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1967
+#: src/lifesim_lib/const.py:1976
 msgid "Jack Draper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1968
+#: src/lifesim_lib/const.py:1977
 msgid "Alex Molcan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1969
+#: src/lifesim_lib/const.py:1978
 msgid "John Isner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1970
+#: src/lifesim_lib/const.py:1979
 msgid "Lorenzo Sonego"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1971
+#: src/lifesim_lib/const.py:1980
 msgid "Andy Murray"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1972
+#: src/lifesim_lib/const.py:1981
 msgid "Jenson Brooksby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1973
+#: src/lifesim_lib/const.py:1982
 msgid "Arthur Rinderknech"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1974
+#: src/lifesim_lib/const.py:1983
 msgid "Filip Krajinovic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1975
+#: src/lifesim_lib/const.py:1984
 msgid "David Goffin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1976
+#: src/lifesim_lib/const.py:1985
 msgid "Oscar Otte"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1977
+#: src/lifesim_lib/const.py:1986
 msgid "Pedro Cachin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1978
+#: src/lifesim_lib/const.py:1987
 msgid "J.J. Wolf"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1979
+#: src/lifesim_lib/const.py:1988
 msgid "Jaume Munar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1980
+#: src/lifesim_lib/const.py:1989
 msgid "Marcos Giron"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1981
+#: src/lifesim_lib/const.py:1990
 msgid "Fabio Fognini"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1982
+#: src/lifesim_lib/const.py:1991
 msgid "Aslan Karatsev"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1983
+#: src/lifesim_lib/const.py:1992
 msgid "Pedro Martinez"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1984
+#: src/lifesim_lib/const.py:1993
 msgid "Marc-Andrea Huesler"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1985
+#: src/lifesim_lib/const.py:1994
 msgid "Benjamin Bonzi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1986
+#: src/lifesim_lib/const.py:1995
 msgid "Corentin Moutet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1987
+#: src/lifesim_lib/const.py:1996
 msgid "Mackenzie McDonald"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1988
+#: src/lifesim_lib/const.py:1997
 msgid "Thiago Monteiro"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1989
+#: src/lifesim_lib/const.py:1998
 msgid "Constant Lestienne"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1990
+#: src/lifesim_lib/const.py:1999
 msgid "Daniel Elahi Galan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1991
+#: src/lifesim_lib/const.py:2000
 msgid "Quentin Halys"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1992
+#: src/lifesim_lib/const.py:2001
 msgid "João Sousa"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1993
+#: src/lifesim_lib/const.py:2002
 msgid "Tallon Griekspoor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1994
+#: src/lifesim_lib/const.py:2003
 msgid "Ilya Ivashka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1995
+#: src/lifesim_lib/const.py:2004
 msgid "Federico Coria"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1996
+#: src/lifesim_lib/const.py:2005
 msgid "Richard Gasquet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1997
+#: src/lifesim_lib/const.py:2006
 msgid "Laslo Djere"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1998
+#: src/lifesim_lib/const.py:2007
 msgid "Mikael Ymer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:1999
+#: src/lifesim_lib/const.py:2008
 msgid "Alejandro Tabilo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2000
+#: src/lifesim_lib/const.py:2009
 msgid "Jiri Lehecka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2001
+#: src/lifesim_lib/const.py:2010
 msgid "Bernabe Zapata Miralles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2002
+#: src/lifesim_lib/const.py:2011
 msgid "Roberto Carballes Baena"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2003
+#: src/lifesim_lib/const.py:2012
 msgid "Radu Albot"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2004
+#: src/lifesim_lib/const.py:2013
 msgid "Kamil Majchrzak"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2005
+#: src/lifesim_lib/const.py:2014
 msgid "Hugo Gaston"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2006
+#: src/lifesim_lib/const.py:2015
 msgid "SoonWoo Kwon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2007
+#: src/lifesim_lib/const.py:2016
 msgid "Jordan Thompson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2008
+#: src/lifesim_lib/const.py:2017
 msgid "Cristian Garin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2009
+#: src/lifesim_lib/const.py:2018
 msgid "Dusan Lajovic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2010
+#: src/lifesim_lib/const.py:2019
 msgid "Chun-Hsin Tseng"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2011
+#: src/lifesim_lib/const.py:2020
 msgid "Tomas Martin Etcheverry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2012
+#: src/lifesim_lib/const.py:2021
 msgid "Taro Daniel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2013
+#: src/lifesim_lib/const.py:2022
 msgid "Thanasi Kokkinakis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2014
+#: src/lifesim_lib/const.py:2023
 msgid "Hugo Dellien"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2015
+#: src/lifesim_lib/const.py:2024
 msgid "Roman Safiullin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2016
+#: src/lifesim_lib/const.py:2025
 msgid "Nikoloz Basilashvili"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2017
+#: src/lifesim_lib/const.py:2026
 msgid "Nuno Borges"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2018
+#: src/lifesim_lib/const.py:2027
 msgid "Pavel Kotov"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2019
+#: src/lifesim_lib/const.py:2028
 msgid "Zhizhen Zhang"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2020
+#: src/lifesim_lib/const.py:2029
 msgid "Alexei Popyrin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2021
+#: src/lifesim_lib/const.py:2030
 msgid "Facundo Bagnis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2022
+#: src/lifesim_lib/const.py:2031
 msgid "Christopher O'Connell"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2026
+#: src/lifesim_lib/const.py:2035
 msgid "Iga Swiatek"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2027
+#: src/lifesim_lib/const.py:2036
 msgid "Ons Jabeur"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2028
+#: src/lifesim_lib/const.py:2037
 msgid "Jessica Pegula"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2029
+#: src/lifesim_lib/const.py:2038
 msgid "Coco Gauff"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2030
+#: src/lifesim_lib/const.py:2039
 msgid "Maria Sakkari"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2031
+#: src/lifesim_lib/const.py:2040
 msgid "Caroline Garcia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2032
+#: src/lifesim_lib/const.py:2041
 msgid "Aryna Sabalenka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2033
+#: src/lifesim_lib/const.py:2042
 msgid "Daria Kasatkina"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2034
+#: src/lifesim_lib/const.py:2043
 msgid "Veronika Kudermetova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2035
+#: src/lifesim_lib/const.py:2044
 msgid "Simona Halep"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2036
+#: src/lifesim_lib/const.py:2045
 msgid "Madison Keys"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2037
+#: src/lifesim_lib/const.py:2046
 msgid "Paula Badosa"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2038
+#: src/lifesim_lib/const.py:2047
 msgid "Belinda Bencic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2039
+#: src/lifesim_lib/const.py:2048
 msgid "Danielle Collins"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2040
+#: src/lifesim_lib/const.py:2049
 msgid "Beatriz Haddad Maia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2041
+#: src/lifesim_lib/const.py:2050
 msgid "Petra Kvitova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2042
+#: src/lifesim_lib/const.py:2051
 msgid "Anett Kontaveit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2043
+#: src/lifesim_lib/const.py:2052
 msgid "Jelena Ostapenko"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2044
+#: src/lifesim_lib/const.py:2053
 msgid "Liudmila Samsonova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2045
+#: src/lifesim_lib/const.py:2054
 msgid "Ekaterina Alexandrova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2046
+#: src/lifesim_lib/const.py:2055
 msgid "Barbora Krejcikova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2047
+#: src/lifesim_lib/const.py:2056
 msgid "Elena Rybakina"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2048
+#: src/lifesim_lib/const.py:2057
 msgid "Amanda Anisimova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2049
+#: src/lifesim_lib/const.py:2058
 msgid "Shuai Zhang"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2050
+#: src/lifesim_lib/const.py:2059
 msgid "Qinwen Zheng"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2051
+#: src/lifesim_lib/const.py:2060
 msgid "Martina Trevisan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2052
+#: src/lifesim_lib/const.py:2061
 msgid "Victoria Azarenka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2053
+#: src/lifesim_lib/const.py:2062
 msgid "Marie Bouzkova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2054
+#: src/lifesim_lib/const.py:2063
 msgid "Kaia Kanepi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2055
+#: src/lifesim_lib/const.py:2064
 msgid "Elise Mertens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2056
+#: src/lifesim_lib/const.py:2065
 msgid "Aliaksandra Sasnovich"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2057
+#: src/lifesim_lib/const.py:2066
 msgid "Karolina Pliskova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2058
+#: src/lifesim_lib/const.py:2067
 msgid "Irina-Camelia Begu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2059
+#: src/lifesim_lib/const.py:2068
 msgid "Ajla Tomljanovic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2060
+#: src/lifesim_lib/const.py:2069
 msgid "Jil Teichmann"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2061
+#: src/lifesim_lib/const.py:2070
 msgid "Alize Cornet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2062
+#: src/lifesim_lib/const.py:2071
 msgid "Sloane Stephens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2063
+#: src/lifesim_lib/const.py:2072
 msgid "Sorana Cirstea"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2064
+#: src/lifesim_lib/const.py:2073
 msgid "Petra Martic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2065
+#: src/lifesim_lib/const.py:2074
 msgid "Leylah Fernandez"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2066
+#: src/lifesim_lib/const.py:2075
 msgid "Alison Riske-Amritraj"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2067
+#: src/lifesim_lib/const.py:2076
 msgid "Shelby Rogers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2068
+#: src/lifesim_lib/const.py:2077
 msgid "Naomi Osaka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2069
+#: src/lifesim_lib/const.py:2078
 msgid "Anastasia Potapova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2070
+#: src/lifesim_lib/const.py:2079
 msgid "Bernarda Pera"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2071
+#: src/lifesim_lib/const.py:2080
 msgid "Bianca Andreescu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2072
+#: src/lifesim_lib/const.py:2081
 msgid "Anhelina Kalinina"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2073
+#: src/lifesim_lib/const.py:2082
 msgid "Ana Bogdan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2074
+#: src/lifesim_lib/const.py:2083
 msgid "Katerina Siniakova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2075
+#: src/lifesim_lib/const.py:2084
 msgid "Mayar Sherif"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2076
+#: src/lifesim_lib/const.py:2085
 msgid "Madison Brengle"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2077
+#: src/lifesim_lib/const.py:2086
 msgid "Xiyu Wang"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2078
+#: src/lifesim_lib/const.py:2087
 msgid "Yulia Putintseva"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2079
+#: src/lifesim_lib/const.py:2088
 msgid "Daria Saville"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2080
+#: src/lifesim_lib/const.py:2089
 msgid "Magda Linette"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2081
+#: src/lifesim_lib/const.py:2090
 msgid "Alison Van Uytvanck"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2082
+#: src/lifesim_lib/const.py:2091
 msgid "Garbine Muguruza"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2083
+#: src/lifesim_lib/const.py:2092
 msgid "Diane Parry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2084
+#: src/lifesim_lib/const.py:2093
 msgid "Anna Bondar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2085
+#: src/lifesim_lib/const.py:2094
 msgid "Claire Liu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2086
+#: src/lifesim_lib/const.py:2095
 msgid "Lucia Bronzetti"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2087
+#: src/lifesim_lib/const.py:2096
 msgid "Lin Zhu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2088
+#: src/lifesim_lib/const.py:2097
 msgid "Anna Kalinskaya"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2089
+#: src/lifesim_lib/const.py:2098
 msgid "Maryna Zanevska"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2090
+#: src/lifesim_lib/const.py:2099
 msgid "Marta Kostyuk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2091
+#: src/lifesim_lib/const.py:2100
 msgid "Jule Niemeier"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2092
+#: src/lifesim_lib/const.py:2101
 msgid "Sara Sorribes Tormo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2093
+#: src/lifesim_lib/const.py:2102
 msgid "Danka Kovinic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2094
+#: src/lifesim_lib/const.py:2103
 msgid "Camila Giorgi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2095
+#: src/lifesim_lib/const.py:2104
 msgid "Tatjana Maria"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2096
+#: src/lifesim_lib/const.py:2105
 msgid "Donna Vekic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2097
+#: src/lifesim_lib/const.py:2106
 msgid "Rebecca Marino"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2098
+#: src/lifesim_lib/const.py:2107
 msgid "Nuria Parrizas Diaz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2099
+#: src/lifesim_lib/const.py:2108
 msgid "Linda Fruhvirtova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2100
+#: src/lifesim_lib/const.py:2109
 msgid "Tereza Martincova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2101
+#: src/lifesim_lib/const.py:2110
 msgid "Emma Raducanu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2102
+#: src/lifesim_lib/const.py:2111
 msgid "Viktorija Golubic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2103
+#: src/lifesim_lib/const.py:2112
 msgid "Jasmine Paolini"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2104
+#: src/lifesim_lib/const.py:2113
 msgid "Elisabetta Cocciaretto"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2105
+#: src/lifesim_lib/const.py:2114
 msgid "Panna Udvardy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2106
+#: src/lifesim_lib/const.py:2115
 msgid "Anna Blinkova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2107
+#: src/lifesim_lib/const.py:2116
 msgid "Lauren Davis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2108
+#: src/lifesim_lib/const.py:2117
 msgid "Yue Yuan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2109
+#: src/lifesim_lib/const.py:2118
 msgid "Dalma Galfi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2110
+#: src/lifesim_lib/const.py:2119
 msgid "Julia Grabher"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2111
+#: src/lifesim_lib/const.py:2120
 msgid "Camila Osorio"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2112
+#: src/lifesim_lib/const.py:2121
 msgid "Harriet Dart"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2113
+#: src/lifesim_lib/const.py:2122
 msgid "Kaja Juvan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2114
+#: src/lifesim_lib/const.py:2123
 msgid "Tamara Zidansek"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2115
+#: src/lifesim_lib/const.py:2124
 msgid "Tamara Korpatsch"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2116
+#: src/lifesim_lib/const.py:2125
 msgid "Linda Noskova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2117
+#: src/lifesim_lib/const.py:2126
 msgid "Viktoriya Tomova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2118
+#: src/lifesim_lib/const.py:2127
 msgid "Qiang Wang"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2119
+#: src/lifesim_lib/const.py:2128
 msgid "Varvara Gracheva"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2120
+#: src/lifesim_lib/const.py:2129
 msgid "Oceane Dodin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2121
+#: src/lifesim_lib/const.py:2130
 msgid "Elena-Gabriela Ruse"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2122
+#: src/lifesim_lib/const.py:2131
 msgid "Aleksandra Krunic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2123
+#: src/lifesim_lib/const.py:2132
 msgid "Dayana Yastremska"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2124
+#: src/lifesim_lib/const.py:2133
 msgid "Angelique Kerber"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2125
+#: src/lifesim_lib/const.py:2134
 msgid "Kamilla Rakhimova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2137
+#: src/lifesim_lib/const.py:2146
 msgid "Taylor Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2138
+#: src/lifesim_lib/const.py:2147
 msgid "Wall Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2139
+#: src/lifesim_lib/const.py:2148
 msgid "Woodland Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2140
+#: src/lifesim_lib/const.py:2149
 msgid "8th Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2141
+#: src/lifesim_lib/const.py:2150
 msgid "Bridle Court"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2142
+#: src/lifesim_lib/const.py:2151
 msgid "Adams Avenue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2143
+#: src/lifesim_lib/const.py:2152
 msgid "5th Street South"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2144
+#: src/lifesim_lib/const.py:2153
 msgid "East Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2145
+#: src/lifesim_lib/const.py:2154
 msgid "Valley View Road"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2146
+#: src/lifesim_lib/const.py:2155
 msgid "Jones Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2147
+#: src/lifesim_lib/const.py:2156
 msgid "Sycamore Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2148
+#: src/lifesim_lib/const.py:2157
 msgid "Chestnut Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2149
+#: src/lifesim_lib/const.py:2158
 msgid "Cedar Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2150
+#: src/lifesim_lib/const.py:2159
 msgid "Jackson Avenue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2151
+#: src/lifesim_lib/const.py:2160
 msgid "Lincoln Avenue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2152
+#: src/lifesim_lib/const.py:2161
 msgid "Inverness Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2153
+#: src/lifesim_lib/const.py:2162
 msgid "Fieldstone Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2154
+#: src/lifesim_lib/const.py:2163
 msgid "Cross Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2155
+#: src/lifesim_lib/const.py:2164
 msgid "Westminster Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2156
+#: src/lifesim_lib/const.py:2165
 msgid "Primrose Lane"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2157
+#: src/lifesim_lib/const.py:2166
 msgid "Canal Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2158
+#: src/lifesim_lib/const.py:2167
 msgid "Grove Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2159
+#: src/lifesim_lib/const.py:2168
 msgid "8th Street West"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2160
+#: src/lifesim_lib/const.py:2169
 msgid "Hill Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2161
+#: src/lifesim_lib/const.py:2170
 msgid "Route 4"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2162
+#: src/lifesim_lib/const.py:2171
 msgid "Locust Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2163
+#: src/lifesim_lib/const.py:2172
 msgid "3rd Street West"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2164
+#: src/lifesim_lib/const.py:2173
 msgid "Buttonwood Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2165
+#: src/lifesim_lib/const.py:2174
 msgid "Pearl Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2166
+#: src/lifesim_lib/const.py:2175
 msgid "B Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2167
+#: src/lifesim_lib/const.py:2176
 msgid "Fairview Road"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2168
+#: src/lifesim_lib/const.py:2177
 msgid "Bridge Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2169
+#: src/lifesim_lib/const.py:2178
 msgid "Orange Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2170
+#: src/lifesim_lib/const.py:2179
 msgid "Holly Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2171
+#: src/lifesim_lib/const.py:2180
 msgid "William Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2172
+#: src/lifesim_lib/const.py:2181
 msgid "Clark Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2173
+#: src/lifesim_lib/const.py:2182
 msgid "Jackson Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2174
+#: src/lifesim_lib/const.py:2183
 msgid "Garfield Avenue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2175
+#: src/lifesim_lib/const.py:2184
 msgid "Sycamore Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2176
+#: src/lifesim_lib/const.py:2185
 msgid "Somerset Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2177
+#: src/lifesim_lib/const.py:2186
 msgid "Bridle Lane"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2178
+#: src/lifesim_lib/const.py:2187
 msgid "North Avenue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2179
+#: src/lifesim_lib/const.py:2188
 msgid "Lexington Court"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2180
+#: src/lifesim_lib/const.py:2189
 msgid "6th Street North"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2181
+#: src/lifesim_lib/const.py:2190
 msgid "Park Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2182
+#: src/lifesim_lib/const.py:2191
 msgid "Walnut Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2183
+#: src/lifesim_lib/const.py:2192
 msgid "Dogwood Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2184
+#: src/lifesim_lib/const.py:2193
 msgid "Highland Drive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2185
+#: src/lifesim_lib/const.py:2194
 msgid "Cottage Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2186
+#: src/lifesim_lib/const.py:2195
 msgid "9th Street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2190
+#: src/lifesim_lib/const.py:2199
 msgid "Busker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2191
+#: src/lifesim_lib/const.py:2200
 msgid "Panhandler"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2192
+#: src/lifesim_lib/const.py:2201
 msgid "Scam Artist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2193
+#: src/lifesim_lib/const.py:2202
 msgid "Street Performer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2198
+#: src/lifesim_lib/const.py:2207
 msgid "Ash Guitar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2199
+#: src/lifesim_lib/const.py:2208
 msgid "Silver Plastic Keyboard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2203
+#: src/lifesim_lib/const.py:2212
 msgid "Classic Rock"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2204
+#: src/lifesim_lib/const.py:2213
 msgid "Reggae"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2205
+#: src/lifesim_lib/const.py:2214
 msgid "Romantic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2206
+#: src/lifesim_lib/const.py:2215
 msgid "Pop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2207
+#: src/lifesim_lib/const.py:2216
 msgid "Funk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2208
+#: src/lifesim_lib/const.py:2217
 msgid "Polka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2209
+#: src/lifesim_lib/const.py:2218
 msgid "Country"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2210
+#: src/lifesim_lib/const.py:2219
 msgid "Bluegrass"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2211
+#: src/lifesim_lib/const.py:2220
 msgid "Renaissance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2212
+#: src/lifesim_lib/const.py:2221
 msgid "New age"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2213
+#: src/lifesim_lib/const.py:2222
 msgid "Adult contemporary"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2214
+#: src/lifesim_lib/const.py:2223
 msgid "House music"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2215
+#: src/lifesim_lib/const.py:2224
 msgid "Synth-pop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2217
+#: src/lifesim_lib/const.py:2226
 msgid "Funk carioca"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2218
+#: src/lifesim_lib/const.py:2227
 msgid "Bossa nova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2219
+#: src/lifesim_lib/const.py:2228
 msgid "Indie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2220
+#: src/lifesim_lib/const.py:2229
 msgid "Elevator music"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2221
+#: src/lifesim_lib/const.py:2230
 msgid "Worship"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2222
+#: src/lifesim_lib/const.py:2231
 msgid "Kawaii metal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2223
+#: src/lifesim_lib/const.py:2232
 msgid "Grunge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2224
+#: src/lifesim_lib/const.py:2233
 msgid "Punk rock"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2225
+#: src/lifesim_lib/const.py:2234
 msgid "Screamo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2226
+#: src/lifesim_lib/const.py:2235
 msgid "Emo pop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2227
+#: src/lifesim_lib/const.py:2236
 msgid "Disco"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2228
+#: src/lifesim_lib/const.py:2237
 msgid "Peaceful"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2229
+#: src/lifesim_lib/const.py:2238
 msgid "Classical"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2230
+#: src/lifesim_lib/const.py:2239
 msgid "Peruvian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2231
+#: src/lifesim_lib/const.py:2240
 msgid "Jazz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2232
+#: src/lifesim_lib/const.py:2241
 msgid "Folk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2233
+#: src/lifesim_lib/const.py:2242
 msgid "Blues"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2240
+#: src/lifesim_lib/const.py:2249
 msgid "Petticoat skirt"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2241
+#: src/lifesim_lib/const.py:2250
 msgid "Trenchcoat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2242
+#: src/lifesim_lib/const.py:2251
 msgid "Angel costume"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2243
+#: src/lifesim_lib/const.py:2252
 msgid "Black turtleneck"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2244
+#: src/lifesim_lib/const.py:2253
 msgid "Dirndl dress"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2246
+#: src/lifesim_lib/const.py:2255
 msgid "Mask"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2247
+#: src/lifesim_lib/const.py:2256
 msgid "Devil costume"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2248
+#: src/lifesim_lib/const.py:2257
 msgid "Poncho"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2250
+#: src/lifesim_lib/const.py:2259
 msgid "Evening dress"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2251
+#: src/lifesim_lib/const.py:2260
 msgid "Business suit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2255
+#: src/lifesim_lib/const.py:2264
 msgid "Top hat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2256
+#: src/lifesim_lib/const.py:2265
 msgid "Raggedy knit cap"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2257
+#: src/lifesim_lib/const.py:2266
 msgid "Shoe box"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2258
+#: src/lifesim_lib/const.py:2267
 msgid "Tip jar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2259
+#: src/lifesim_lib/const.py:2268
 msgid "Music instrument case"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2260
+#: src/lifesim_lib/const.py:2269
 msgid "Gas station soda cup"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2261
+#: src/lifesim_lib/const.py:2270
 msgid "Glass fishbowl"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2262
+#: src/lifesim_lib/const.py:2271
 msgid "Crusty tupperware container"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2263
+#: src/lifesim_lib/const.py:2272
 msgid "Rusty bucket"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2264
+#: src/lifesim_lib/const.py:2273
 msgid "Baseball cap"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2265
+#: src/lifesim_lib/const.py:2274
 msgid "Coffee tin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2266
+#: src/lifesim_lib/const.py:2275
 msgid "Backpack"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2267
+#: src/lifesim_lib/const.py:2276
 msgid "Hobo stick"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2272
+#: src/lifesim_lib/const.py:2281
 msgid "Hazmat suit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2273
+#: src/lifesim_lib/const.py:2282
 msgid "Straw hat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2274
+#: src/lifesim_lib/const.py:2283
 msgid "Hobo sack"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2275
+#: src/lifesim_lib/const.py:2284
 msgid "Tattered suit and tie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2276
+#: src/lifesim_lib/const.py:2285
 msgid "Walker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2277
+#: src/lifesim_lib/const.py:2286
 msgid "Eviction notice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2278
+#: src/lifesim_lib/const.py:2287
 msgid "Plaster cast"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2279
+#: src/lifesim_lib/const.py:2288
 msgid "Arm sling"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2280
+#: src/lifesim_lib/const.py:2289
 msgid "Matted fur coat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2284
+#: src/lifesim_lib/const.py:2293
 msgid "Let's do lunch, U buy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2285
+#: src/lifesim_lib/const.py:2294
 msgid "Will take insults for money"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2286
+#: src/lifesim_lib/const.py:2295
 msgid "Free Hugs!"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2287
+#: src/lifesim_lib/const.py:2296
 msgid "Need money for food"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2288
+#: src/lifesim_lib/const.py:2297
 msgid "I'm too sober for this"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2289
+#: src/lifesim_lib/const.py:2298
 msgid "Will picket your boss' house..."
 msgstr ""
 
-#: src/lifesim_lib/const.py:2290
+#: src/lifesim_lib/const.py:2299
 msgid "I'll let you spank me for $1"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2291
+#: src/lifesim_lib/const.py:2300
 msgid "Saving up for a better life"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2292
+#: src/lifesim_lib/const.py:2301
 msgid "Psychiatric help: $1"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2293
+#: src/lifesim_lib/const.py:2302
 msgid "I need tree fiddy..."
 msgstr ""
 
-#: src/lifesim_lib/const.py:2297
+#: src/lifesim_lib/const.py:2306
 msgid "Garbage can lid"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2298
+#: src/lifesim_lib/const.py:2307
 msgid "Paper bag"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2299
+#: src/lifesim_lib/const.py:2308
 msgid "Red Solo cup"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2300
+#: src/lifesim_lib/const.py:2309
 msgid "Tattered picnic basket"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2301
+#: src/lifesim_lib/const.py:2310
 msgid "Coffee canister"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2302
+#: src/lifesim_lib/const.py:2311
 msgid "Empty MacBook Pro box"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2303
+#: src/lifesim_lib/const.py:2312
 msgid "Cast-iron skillet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2304
+#: src/lifesim_lib/const.py:2313
 msgid "Duffel bag"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2305
+#: src/lifesim_lib/const.py:2314
 msgid "Plastic shopping bag"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2309
+#: src/lifesim_lib/const.py:2318
 msgid "Hang outside a halfway house"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2310
+#: src/lifesim_lib/const.py:2319
 msgid "Go to a packed convention centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2311
+#: src/lifesim_lib/const.py:2320
 msgid "Hang around the entrance to a mall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2312
+#: src/lifesim_lib/const.py:2321
 msgid "Rush up to pedestrians"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2313
+#: src/lifesim_lib/const.py:2322
 msgid "Sit outside a train station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2314
+#: src/lifesim_lib/const.py:2323
 msgid "Walk around a farmers market"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2315
+#: src/lifesim_lib/const.py:2324
 msgid "Pass out on the street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2316
+#: src/lifesim_lib/const.py:2325
 msgid "Sit in front of a church on Sunday"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2317
+#: src/lifesim_lib/const.py:2326
 msgid "Approach people leaving a concert hall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2318
+#: src/lifesim_lib/const.py:2327
 msgid "Stand on a corner known for drug dealing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2338
+#: src/lifesim_lib/const.py:2347
 msgid "Straight"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2339
+#: src/lifesim_lib/const.py:2348
 msgid "Bi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2340
+#: src/lifesim_lib/const.py:2349
 msgid "Gay"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2346 src/lifesim_lib/const.py:2352
+#: src/lifesim_lib/const.py:2355 src/lifesim_lib/const.py:2361
 msgid "Cisgender"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2347 src/lifesim_lib/const.py:2353
+#: src/lifesim_lib/const.py:2356 src/lifesim_lib/const.py:2362
 msgid "Genderqueer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2348 src/lifesim_lib/const.py:2354
+#: src/lifesim_lib/const.py:2357 src/lifesim_lib/const.py:2363
 msgid "Non-Binary"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2349
+#: src/lifesim_lib/const.py:2358
 msgid "Transgender Male"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2355
+#: src/lifesim_lib/const.py:2364
 msgid "Transgender Female"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2367
+#: src/lifesim_lib/const.py:2376
 msgid "Ice Bucket Challenge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2372
+#: src/lifesim_lib/const.py:2381
 msgid "tap dancing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2375
+#: src/lifesim_lib/const.py:2384
 msgid "a P!nk song"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2379
+#: src/lifesim_lib/const.py:2388
 msgid "a cute"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2380
+#: src/lifesim_lib/const.py:2389
 msgid "an embarrasing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2384
+#: src/lifesim_lib/const.py:2393
 msgid "a photo of a cake you found on the internet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2385
+#: src/lifesim_lib/const.py:2394
 msgid "your nasty snack"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2389
+#: src/lifesim_lib/const.py:2398
 msgid "a ridiculous"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2393
+#: src/lifesim_lib/const.py:2402
 msgid "an inspirational"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2396
+#: src/lifesim_lib/const.py:2405
 msgid "relationships"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2400
+#: src/lifesim_lib/const.py:2409
 msgid "promoting your political ideology"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2401
+#: src/lifesim_lib/const.py:2410
 msgid "campaigning for your political ideology"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2402
+#: src/lifesim_lib/const.py:2411
 msgid "supporting your favourite political candidate"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2406
+#: src/lifesim_lib/const.py:2415
 msgid "Which social media platform is the best?"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2407
+#: src/lifesim_lib/const.py:2416
 msgid "What is the best song?"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2411
+#: src/lifesim_lib/const.py:2420
 msgid "an outlandish"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2414
+#: src/lifesim_lib/const.py:2423
 msgid "yourself talking with accents"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2418 src/lifesim_lib/const.py:2427
-#: src/lifesim_lib/const.py:2436
+#: src/lifesim_lib/const.py:2427 src/lifesim_lib/const.py:2436
+#: src/lifesim_lib/const.py:2445
 msgid "a meme"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2419 src/lifesim_lib/const.py:2428
-#: src/lifesim_lib/const.py:2437
+#: src/lifesim_lib/const.py:2428 src/lifesim_lib/const.py:2437
+#: src/lifesim_lib/const.py:2446
 msgid "a photo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2420 src/lifesim_lib/const.py:2429
-#: src/lifesim_lib/const.py:2438
+#: src/lifesim_lib/const.py:2429 src/lifesim_lib/const.py:2438
+#: src/lifesim_lib/const.py:2447
 msgid "a picture"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2421 src/lifesim_lib/const.py:2430
-#: src/lifesim_lib/const.py:2440
+#: src/lifesim_lib/const.py:2430 src/lifesim_lib/const.py:2439
+#: src/lifesim_lib/const.py:2449
 msgid "a reel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2422 src/lifesim_lib/const.py:2431
-#: src/lifesim_lib/const.py:2442
+#: src/lifesim_lib/const.py:2431 src/lifesim_lib/const.py:2440
+#: src/lifesim_lib/const.py:2451
 msgid "a story"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2423 src/lifesim_lib/const.py:2432
-#: src/lifesim_lib/const.py:2443
+#: src/lifesim_lib/const.py:2432 src/lifesim_lib/const.py:2441
+#: src/lifesim_lib/const.py:2452
 msgid "a video"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2439
+#: src/lifesim_lib/const.py:2448
 msgid "a recording session"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2441
+#: src/lifesim_lib/const.py:2450
 msgid "a song"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2444
+#: src/lifesim_lib/const.py:2453
 msgid "their latest album cover"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2448
+#: src/lifesim_lib/const.py:2457
 msgid "a duck face selfie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2449
+#: src/lifesim_lib/const.py:2458
 msgid "a selfie pulling a funny face"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2450
+#: src/lifesim_lib/const.py:2459
 msgid "a professional looking selfie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2454 src/lifesim_lib/const.py:2461
+#: src/lifesim_lib/const.py:2463 src/lifesim_lib/const.py:2470
 msgid "a risqué selfie of yourself"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2455
+#: src/lifesim_lib/const.py:2464
 msgid "a photo of yourself clearly showing your muscles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2456
+#: src/lifesim_lib/const.py:2465
 msgid "a selfie gazing through the lens dreamily"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2457 src/lifesim_lib/const.py:2464
+#: src/lifesim_lib/const.py:2466 src/lifesim_lib/const.py:2473
 msgid "a gym selfie while working out"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2462
+#: src/lifesim_lib/const.py:2471
 msgid "a side-on mirror selfie emphasising your tight dress"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2463
+#: src/lifesim_lib/const.py:2472
 msgid "an over-the-shoulder bikini selfie showing your bum in the background"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2468
+#: src/lifesim_lib/const.py:2477
 msgid "and your friend made a slapstick skit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2472
+#: src/lifesim_lib/const.py:2481
 msgid "supporting social justice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2476
+#: src/lifesim_lib/const.py:2485
 msgid "about your weird day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2480
+#: src/lifesim_lib/const.py:2489
 msgid "holding a water pistol and wearing white underwear"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2481
+#: src/lifesim_lib/const.py:2490
 msgid "looking off into the distance and only wearing a towel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2482
+#: src/lifesim_lib/const.py:2491
 msgid "taking a shower through half-fogged glass"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2483
+#: src/lifesim_lib/const.py:2492
 msgid "wearing a sexy bathing suit while taking a shower"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2484 src/lifesim_lib/const.py:2505
+#: src/lifesim_lib/const.py:2493 src/lifesim_lib/const.py:2514
 msgid "wearing just a pair of jeans while mowing the lawn"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2485
+#: src/lifesim_lib/const.py:2494
 msgid "wearing just a t-shirt"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2486
+#: src/lifesim_lib/const.py:2495
 msgid "wearing just a t-shirt while laying on the dinner table"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2487
+#: src/lifesim_lib/const.py:2496
 msgid "wearing nothing while making a duck face"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2488
+#: src/lifesim_lib/const.py:2497
 msgid "wearing nothing while riding an inflatable Orca in the swimming pool"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2489
+#: src/lifesim_lib/const.py:2498
 msgid "wearing only sushi while reading a book"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2490
+#: src/lifesim_lib/const.py:2499
 msgid "wearing practically nothing while laying in bed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2491
+#: src/lifesim_lib/const.py:2500
 msgid "wearing practically nothing while posing in the bathroom mirror"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2492
+#: src/lifesim_lib/const.py:2501
 msgid "wearing your birthday suit while pretending to sleep"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2495
+#: src/lifesim_lib/const.py:2504
 msgid "not wearing your bikini bottoms while laying by the pool"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2496
+#: src/lifesim_lib/const.py:2505
 msgid "wearing a thong while eating a cucumber"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2497
+#: src/lifesim_lib/const.py:2506
 msgid "wearing a thong while sprawled out on the floor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2498
+#: src/lifesim_lib/const.py:2507
 msgid "wearing edible underwear while dancing at home"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2499
+#: src/lifesim_lib/const.py:2508
 msgid "wearing edible underwear while laying on the dinner table"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2500
+#: src/lifesim_lib/const.py:2509
 msgid "wearing just a t-shirt while eating a cucumber"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2503
+#: src/lifesim_lib/const.py:2512
 msgid "as 'The Naked Chef'"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2504
+#: src/lifesim_lib/const.py:2513
 msgid "wearing a suit while eating a cherry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2506
+#: src/lifesim_lib/const.py:2515
 msgid "flexing your muscles while shaving your beard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2510
+#: src/lifesim_lib/const.py:2519
 msgid "some magnificent art photos"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2511
+#: src/lifesim_lib/const.py:2520
 msgid "a stunning night video"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2512
+#: src/lifesim_lib/const.py:2521
 msgid "a video of yourself walking through markets"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2515
+#: src/lifesim_lib/const.py:2524
 msgid "from your last vacation"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2516
+#: src/lifesim_lib/const.py:2525
 msgid "from your trip to Paris"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2517
+#: src/lifesim_lib/const.py:2526
 msgid "you took on your Hawaiian trip"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2521
+#: src/lifesim_lib/const.py:2530
 msgid "your daily life shenanigans as a vlog"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2522
+#: src/lifesim_lib/const.py:2531
 msgid "a vlog of your morning routine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2528
+#: src/lifesim_lib/const.py:2537
 msgid "@2OldForThis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2529
+#: src/lifesim_lib/const.py:2538
 msgid "@TheTroubleMakers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2530
+#: src/lifesim_lib/const.py:2539
 msgid "@joe_not_exotic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2531
+#: src/lifesim_lib/const.py:2540
 msgid "@shaquille.oatmeal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2532
+#: src/lifesim_lib/const.py:2541
 msgid "@RenegadeMaster"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2533
+#: src/lifesim_lib/const.py:2542
 msgid "@viewer_discretion_advised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2534
+#: src/lifesim_lib/const.py:2543
 msgid "@FunnyCatVidz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2535
+#: src/lifesim_lib/const.py:2544
 msgid "@CharliDamelioForPresident"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2536
+#: src/lifesim_lib/const.py:2545
 msgid "@everythingbagelwithvegancreamcheese"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2537
+#: src/lifesim_lib/const.py:2546
 msgid "@name_is_in_use"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2538
+#: src/lifesim_lib/const.py:2547
 msgid "@i_dont_dance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2539
+#: src/lifesim_lib/const.py:2548
 msgid "@builtdifferent"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2540
+#: src/lifesim_lib/const.py:2549
 msgid "@shadowbanned"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2541
+#: src/lifesim_lib/const.py:2550
 msgid "@not_my_idea"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2542
+#: src/lifesim_lib/const.py:2551
 msgid "@down_with_the_kids"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2543
+#: src/lifesim_lib/const.py:2552
 msgid "@amicoolyet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2544
+#: src/lifesim_lib/const.py:2553
 msgid "@Addison_Rae_Of_Sunshine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2545
+#: src/lifesim_lib/const.py:2554
 msgid "@im_an_accountant"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2546
+#: src/lifesim_lib/const.py:2555
 msgid "@IYELLALOT"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2547
+#: src/lifesim_lib/const.py:2556
 msgid "@FrostedCupcake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2548
+#: src/lifesim_lib/const.py:2557
 msgid "@Avocadorable"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2549
+#: src/lifesim_lib/const.py:2558
 msgid "@MrsDracoMalfoy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2550
+#: src/lifesim_lib/const.py:2559
 msgid "@MrsChalamet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2551
+#: src/lifesim_lib/const.py:2560
 msgid "@MrsStyles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2552
+#: src/lifesim_lib/const.py:2561
 msgid "@CourtesyFlush"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2553
+#: src/lifesim_lib/const.py:2562
 msgid "@MomsSpaghetti"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2554
+#: src/lifesim_lib/const.py:2563
 msgid "@just_a_teen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2555
+#: src/lifesim_lib/const.py:2564
 msgid "@GenZWarrior"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2556
+#: src/lifesim_lib/const.py:2565
 msgid "@what_does_this_button_do"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2557
+#: src/lifesim_lib/const.py:2566
 msgid "@not_funny"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2558
+#: src/lifesim_lib/const.py:2567
 msgid "@DestinysGrandchild"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2559
+#: src/lifesim_lib/const.py:2568
 msgid "@champain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2560
+#: src/lifesim_lib/const.py:2569
 msgid "@AspiringInfluencer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2561
+#: src/lifesim_lib/const.py:2570
 msgid "@ClassyBadassy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2562
+#: src/lifesim_lib/const.py:2571
 msgid "@severusvape"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2563
+#: src/lifesim_lib/const.py:2572
 msgid "@RuleFollower"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2564
+#: src/lifesim_lib/const.py:2573
 msgid "@Lizzos_Flute"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2565
+#: src/lifesim_lib/const.py:2574
 msgid "@urcutejeans"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2566
+#: src/lifesim_lib/const.py:2575
 msgid "@guess_who"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2567
+#: src/lifesim_lib/const.py:2576
 msgid "@insert_name_here"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2568
+#: src/lifesim_lib/const.py:2577
 msgid "@InstagramM0del"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2569
+#: src/lifesim_lib/const.py:2578
 msgid "@baeconandeggz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2570
+#: src/lifesim_lib/const.py:2579
 msgid "@look_mom"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2571
+#: src/lifesim_lib/const.py:2580
 msgid "@botaccount"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2572
+#: src/lifesim_lib/const.py:2581
 msgid "@QuarQueen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2573
+#: src/lifesim_lib/const.py:2582
 msgid "@Reese_Withoutaspoon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2574
+#: src/lifesim_lib/const.py:2583
 msgid "@ReeseWithafork"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2575
+#: src/lifesim_lib/const.py:2584
 msgid "@ImageNotUploaded"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2576
+#: src/lifesim_lib/const.py:2585
 msgid "@No_Feet_Pics"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2577
+#: src/lifesim_lib/const.py:2586
 msgid "@wherearethetomatoes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2578
+#: src/lifesim_lib/const.py:2587
 msgid "@TequilaMockingbird"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2579
+#: src/lifesim_lib/const.py:2588
 msgid "@the_other_name_were_taken"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2580
+#: src/lifesim_lib/const.py:2589
 msgid "@not_my_first_choice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2581
+#: src/lifesim_lib/const.py:2590
 msgid "@PaintMeLikeOneOfYourFrenchGirls"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2582
+#: src/lifesim_lib/const.py:2591
 msgid "@Hot_Name_Here"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2583
+#: src/lifesim_lib/const.py:2592
 msgid "@InstagramHubby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2584
+#: src/lifesim_lib/const.py:2593
 msgid "@BasicBeach"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2585
+#: src/lifesim_lib/const.py:2594
 msgid "@thot_patrol"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2586
+#: src/lifesim_lib/const.py:2595
 msgid "@my_anaconda_does"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2587
+#: src/lifesim_lib/const.py:2596
 msgid "@kim_chi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2588
+#: src/lifesim_lib/const.py:2597
 msgid "@username_copied"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2589
+#: src/lifesim_lib/const.py:2598
 msgid "@Ariana_Grandes_Ponytail"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2590
+#: src/lifesim_lib/const.py:2599
 msgid "@definitely_not_an_athlete"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2591
+#: src/lifesim_lib/const.py:2600
 msgid "@will_pay_extra_for_guac"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2592
+#: src/lifesim_lib/const.py:2601
 msgid "@not_my_1st_rodeo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2593
+#: src/lifesim_lib/const.py:2602
 msgid "@coolshirtbra"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2594
+#: src/lifesim_lib/const.py:2603
 msgid "@DMmeforcompliments"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2595
+#: src/lifesim_lib/const.py:2604
 msgid "@baecon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2596
+#: src/lifesim_lib/const.py:2605
 msgid "@boneappleteeth"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2597
+#: src/lifesim_lib/const.py:2606
 msgid "@valid8me"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2598
+#: src/lifesim_lib/const.py:2607
 msgid "@personallyvictimizedbyreginageorge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2599
+#: src/lifesim_lib/const.py:2608
 msgid "@been_there_done_that"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2600
+#: src/lifesim_lib/const.py:2609
 msgid "@hi_future_employers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2601
+#: src/lifesim_lib/const.py:2610
 msgid "@chalametbmybae"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2602
+#: src/lifesim_lib/const.py:2611
 msgid "@NorthWestsAssistant"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2603
+#: src/lifesim_lib/const.py:2612
 msgid "@hotgirlbummer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2608
+#: src/lifesim_lib/const.py:2617
 msgid "you look sinister"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2609
+#: src/lifesim_lib/const.py:2618
 msgid "your thoughts are absurd"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2722
+#: src/lifesim_lib/const.py:2731
 msgid "Alice's Adventure's In Wonderland"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2722
+#: src/lifesim_lib/const.py:2731
 msgid "Fantasy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2723
+#: src/lifesim_lib/const.py:2732
 msgid "Atlas Shrugged"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2723
+#: src/lifesim_lib/const.py:2732
 msgid "Novel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2724
+#: src/lifesim_lib/const.py:2733
 msgid "Autobiography"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2724
+#: src/lifesim_lib/const.py:2733
 msgid "Becoming"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2725
+#: src/lifesim_lib/const.py:2734
 msgid "Brown Bear, Brown Bear, What Do You See?"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2725 src/lifesim_lib/const.py:2727
-#: src/lifesim_lib/const.py:2733 src/lifesim_lib/const.py:2734
-#: src/lifesim_lib/const.py:2735 src/lifesim_lib/const.py:2736
-#: src/lifesim_lib/const.py:2737
+#: src/lifesim_lib/const.py:2734 src/lifesim_lib/const.py:2736
+#: src/lifesim_lib/const.py:2742 src/lifesim_lib/const.py:2743
+#: src/lifesim_lib/const.py:2744 src/lifesim_lib/const.py:2745
+#: src/lifesim_lib/const.py:2746
 msgid "Children's Picture Book"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2726
+#: src/lifesim_lib/const.py:2735
 msgid "Captain Underpants and the Attack of the Talking Toilets"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2726 src/lifesim_lib/const.py:2729
-#: src/lifesim_lib/const.py:2730
+#: src/lifesim_lib/const.py:2735 src/lifesim_lib/const.py:2738
+#: src/lifesim_lib/const.py:2739
 msgid "Children's Novel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2727
+#: src/lifesim_lib/const.py:2736
 msgid "Corduroy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2728
+#: src/lifesim_lib/const.py:2737
 msgid "Cosmos"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2728
+#: src/lifesim_lib/const.py:2737
 msgid "Non-fiction"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2729
+#: src/lifesim_lib/const.py:2738
 msgid "Diary of a Wimpy Kid"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2730
+#: src/lifesim_lib/const.py:2739
 msgid "Goosebumps"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2731
+#: src/lifesim_lib/const.py:2740
 msgid "Hatchet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2731
+#: src/lifesim_lib/const.py:2740
 msgid "Young Adult Novel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2732
+#: src/lifesim_lib/const.py:2741
 msgid "I, Robot"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2732
+#: src/lifesim_lib/const.py:2741
 msgid "Science Fiction"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2733
+#: src/lifesim_lib/const.py:2742
 msgid "If You Give a Mouse a Cookie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2734
+#: src/lifesim_lib/const.py:2743
 msgid "Stellaluna"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2735
+#: src/lifesim_lib/const.py:2744
 msgid "The Cat in the Hat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2736
+#: src/lifesim_lib/const.py:2745
 msgid "The Little Engine That Could"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2737
+#: src/lifesim_lib/const.py:2746
 msgid "The Very Hungry Caterpillar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2745
+#: src/lifesim_lib/const.py:2754
 msgid "20,000 Leagues Under the Sea"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2746
+#: src/lifesim_lib/const.py:2755
 msgid "2001: A Space Odyssey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2747
+#: src/lifesim_lib/const.py:2756
 msgid "Aladdin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2748
+#: src/lifesim_lib/const.py:2757
 msgid "Alice in Wonderland"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2749
+#: src/lifesim_lib/const.py:2758
 msgid "All Quiet on the Western Front"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2750
+#: src/lifesim_lib/const.py:2759
 msgid "Aquaman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2751
+#: src/lifesim_lib/const.py:2760
 msgid "Armageddon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2752
+#: src/lifesim_lib/const.py:2761
 msgid "Avatar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2753
+#: src/lifesim_lib/const.py:2762
 msgid "Avengers: Age of Ultron"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2754
+#: src/lifesim_lib/const.py:2763
 msgid "Avengers: Endgame"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2755
+#: src/lifesim_lib/const.py:2764
 msgid "Avengers: Infinity War"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2756
+#: src/lifesim_lib/const.py:2765
 msgid "Back to the Future"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2757
+#: src/lifesim_lib/const.py:2766
 msgid "Bambi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2758
+#: src/lifesim_lib/const.py:2767
 msgid "Beauty and the Beast"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2759
+#: src/lifesim_lib/const.py:2768
 msgid "Ben-Hur"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2760
+#: src/lifesim_lib/const.py:2769
 msgid "Black Panther"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2761
+#: src/lifesim_lib/const.py:2770
 msgid "Boom Town"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2762
+#: src/lifesim_lib/const.py:2771
 msgid "Butch Cassidy and the Sundance Kid"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2763
+#: src/lifesim_lib/const.py:2772
 msgid "Captain America: Civil War"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2764
+#: src/lifesim_lib/const.py:2773
 msgid "Captain Marvel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2765
+#: src/lifesim_lib/const.py:2774
 msgid "Cavalcade"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2766
+#: src/lifesim_lib/const.py:2775
 msgid "Cinderella"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2767
+#: src/lifesim_lib/const.py:2776
 msgid "Cinerama Holiday"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2768
+#: src/lifesim_lib/const.py:2777
 msgid "City Lights"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2769
+#: src/lifesim_lib/const.py:2778
 msgid "Cleopatra"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2770
+#: src/lifesim_lib/const.py:2779
 msgid "Demon Slayer: Mugen Train"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2771
+#: src/lifesim_lib/const.py:2780
 msgid "Despicable Me 3"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2772
+#: src/lifesim_lib/const.py:2781
 msgid "Diamonds Are Forever"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2773
+#: src/lifesim_lib/const.py:2782
 msgid "Die Hard with a Vengeance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2774
+#: src/lifesim_lib/const.py:2783
 msgid "Douglas Fairbanks in Robin Hood"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2775
+#: src/lifesim_lib/const.py:2784
 msgid "Duel in the Sun"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2776
+#: src/lifesim_lib/const.py:2785
 msgid "E.T. the Extra-Terrestrial"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2777
+#: src/lifesim_lib/const.py:2786
 msgid "Easter Parade"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2778
+#: src/lifesim_lib/const.py:2787
 msgid "Fatal Attraction"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2779
+#: src/lifesim_lib/const.py:2788
 msgid "Fiddler on the Roof"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2780
+#: src/lifesim_lib/const.py:2789
 msgid "Finding Dory"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2781
+#: src/lifesim_lib/const.py:2790
 msgid "For Heaven's Sake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2782
+#: src/lifesim_lib/const.py:2791
 msgid "For Whom the Bell Tolls"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2783
+#: src/lifesim_lib/const.py:2792
 msgid "Forever Amber"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2784
+#: src/lifesim_lib/const.py:2793
 msgid "Frankenstein"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2785
+#: src/lifesim_lib/const.py:2794
 msgid "From Russia with Love"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2786
+#: src/lifesim_lib/const.py:2795
 msgid "Frozen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2787
+#: src/lifesim_lib/const.py:2796
 msgid "Frozen II"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2788
+#: src/lifesim_lib/const.py:2797
 msgid "Funny Girl"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2789
+#: src/lifesim_lib/const.py:2798
 msgid "Furious 7"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2790 src/lifesim_lib/const.py:4139
+#: src/lifesim_lib/const.py:2799 src/lifesim_lib/const.py:4148
 msgid "Ghost"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2791
+#: src/lifesim_lib/const.py:2800
 msgid "Going My Way"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2792
+#: src/lifesim_lib/const.py:2801
 msgid "Goldfinger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2793
+#: src/lifesim_lib/const.py:2802
 msgid "Gone with the Wind"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2794
+#: src/lifesim_lib/const.py:2803
 msgid "Grease"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2795
+#: src/lifesim_lib/const.py:2804
 msgid "Harry Potter and the Deathly Hallows – Part 2"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2796
+#: src/lifesim_lib/const.py:2805
 msgid "Harry Potter and the Goblet of Fire"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2797
+#: src/lifesim_lib/const.py:2806
 msgid "Harry Potter and the Philosopher's Stone"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2798
+#: src/lifesim_lib/const.py:2807
 msgid "Hawaii"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2799
+#: src/lifesim_lib/const.py:2808
 msgid "How the West Was Won"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2800
+#: src/lifesim_lib/const.py:2809
 msgid "I'm No Angel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2801
+#: src/lifesim_lib/const.py:2810
 msgid "Incredibles 2"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2802
+#: src/lifesim_lib/const.py:2811
 msgid "Independence Day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2803
+#: src/lifesim_lib/const.py:2812
 msgid "Indiana Jones and the Last Crusade"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2804
+#: src/lifesim_lib/const.py:2813
 msgid "Indiana Jones and the Temple of Doom"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2805
+#: src/lifesim_lib/const.py:2814
 msgid "Intolerance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2806
+#: src/lifesim_lib/const.py:2815
 msgid "Iron Man 3"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2807
+#: src/lifesim_lib/const.py:2816
 msgid "It Happened One Night"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2808
+#: src/lifesim_lib/const.py:2817
 msgid "Jaws"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2809
+#: src/lifesim_lib/const.py:2818
 msgid "Joker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2810
+#: src/lifesim_lib/const.py:2819
 msgid "Jurassic Park"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2811
+#: src/lifesim_lib/const.py:2820
 msgid "Jurassic World"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2812
+#: src/lifesim_lib/const.py:2821
 msgid "Jurassic World Dominion"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2813
+#: src/lifesim_lib/const.py:2822
 msgid "Jurassic World: Fallen Kingdom"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2814
+#: src/lifesim_lib/const.py:2823
 msgid "King Kong"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2815
+#: src/lifesim_lib/const.py:2824
 msgid "King Solomon's Mines"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2816
+#: src/lifesim_lib/const.py:2825
 msgid "Lady and the Tramp"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2817
+#: src/lifesim_lib/const.py:2826
 msgid "Lawrence of Arabia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2818
+#: src/lifesim_lib/const.py:2827
 msgid "Love Story"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2819
+#: src/lifesim_lib/const.py:2828
 msgid "Mary Poppins"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2820
+#: src/lifesim_lib/const.py:2829
 msgid "Mickey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2821
+#: src/lifesim_lib/const.py:2830
 msgid "Minions"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2822
+#: src/lifesim_lib/const.py:2831
 msgid "Mission: Impossible 2"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2823
+#: src/lifesim_lib/const.py:2832
 msgid "Mister Roberts"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2824
+#: src/lifesim_lib/const.py:2833
 msgid "Mom and Dad"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2825
+#: src/lifesim_lib/const.py:2834
 msgid "Moonraker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2826
+#: src/lifesim_lib/const.py:2835
 msgid "Mrs. Miniver"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2827
+#: src/lifesim_lib/const.py:2836
 msgid "Mutiny on the Bounty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2828
+#: src/lifesim_lib/const.py:2837
 msgid "My Fair Lady"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2829
+#: src/lifesim_lib/const.py:2838
 msgid "One Hundred and One Dalmatians"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2830
+#: src/lifesim_lib/const.py:2839
 msgid "Peter Pan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2831
+#: src/lifesim_lib/const.py:2840
 msgid "Pinocchio"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2832
+#: src/lifesim_lib/const.py:2841
 msgid "Pirates of the Caribbean: At World's End"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2833
+#: src/lifesim_lib/const.py:2842
 msgid "Pirates of the Caribbean: Dead Man's Chest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2834
+#: src/lifesim_lib/const.py:2843
 msgid "Pirates of the Caribbean: On Stranger Tides"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2835
+#: src/lifesim_lib/const.py:2844
 msgid "Psycho"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2836
+#: src/lifesim_lib/const.py:2845
 msgid "Quo Vadis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2837
+#: src/lifesim_lib/const.py:2846
 msgid "Raiders of the Lost Ark"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2838
+#: src/lifesim_lib/const.py:2847
 msgid "Rain Man"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2839
+#: src/lifesim_lib/const.py:2848
 msgid "Rear Window"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2840
+#: src/lifesim_lib/const.py:2849
 msgid "Return of the Jedi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2841 src/lifesim_lib/const.py:3871
-#: src/lifesim_lib/const.py:4053
+#: src/lifesim_lib/const.py:2850 src/lifesim_lib/const.py:3880
+#: src/lifesim_lib/const.py:4062
 msgid "Rocky"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2842
+#: src/lifesim_lib/const.py:2851
 msgid "Rocky II"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2843
+#: src/lifesim_lib/const.py:2852
 msgid "Rogue One: A Star Wars Story"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2844
+#: src/lifesim_lib/const.py:2853
 msgid "Samson and Delilah"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2845
+#: src/lifesim_lib/const.py:2854
 msgid "San Francisco"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2846
+#: src/lifesim_lib/const.py:2855
 msgid "Sergeant York"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2847
+#: src/lifesim_lib/const.py:2856
 msgid "She Done Him Wrong"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2848
+#: src/lifesim_lib/const.py:2857
 msgid "Shrek 2"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2849
+#: src/lifesim_lib/const.py:2858
 msgid "Skyfall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2850
+#: src/lifesim_lib/const.py:2859
 msgid "Snow White and the Seven Dwarfs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2851
+#: src/lifesim_lib/const.py:2860
 msgid "Song of the South"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2852
+#: src/lifesim_lib/const.py:2861
 msgid "South Pacific"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2853
+#: src/lifesim_lib/const.py:2862
 msgid "Spartacus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2854
+#: src/lifesim_lib/const.py:2863
 msgid "Spider-Man: Far From Home"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2855
+#: src/lifesim_lib/const.py:2864
 msgid "Spider-Man: No Way Home"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2856
+#: src/lifesim_lib/const.py:2865
 msgid "Star Wars"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2857
+#: src/lifesim_lib/const.py:2866
 msgid "Star Wars: Episode I – The Phantom Menace"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2858
+#: src/lifesim_lib/const.py:2867
 msgid "Star Wars: The Force Awakens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2859
+#: src/lifesim_lib/const.py:2868
 msgid "Star Wars: The Last Jedi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2860
+#: src/lifesim_lib/const.py:2869
 msgid "Star Wars: The Rise of Skywalker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2861
+#: src/lifesim_lib/const.py:2870
 msgid "Sunny Side Up"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2862
+#: src/lifesim_lib/const.py:2871
 msgid "Swiss Family Robinson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2863
+#: src/lifesim_lib/const.py:2872
 msgid "Terminator 2: Judgment Day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2864
+#: src/lifesim_lib/const.py:2873
 msgid "The Avengers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2865
+#: src/lifesim_lib/const.py:2874
 msgid "The Bells of St. Mary's"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2866
+#: src/lifesim_lib/const.py:2875
 msgid "The Best Years of Our Lives"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2867
+#: src/lifesim_lib/const.py:2876
 msgid "The Bible: In the Beginning"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2868
+#: src/lifesim_lib/const.py:2877
 msgid "The Big Parade"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2869
+#: src/lifesim_lib/const.py:2878
 msgid "The Birth of a Nation"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2870
+#: src/lifesim_lib/const.py:2879
 msgid "The Bridge on the River Kwai"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2871
+#: src/lifesim_lib/const.py:2880
 msgid "The Broadway Melody"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2872
+#: src/lifesim_lib/const.py:2881
 msgid "The Covered Wagon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2873
+#: src/lifesim_lib/const.py:2882
 msgid "The Dark Knight"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2874
+#: src/lifesim_lib/const.py:2883
 msgid "The Dark Knight Rises"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2875
+#: src/lifesim_lib/const.py:2884
 msgid "The Empire Strikes Back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2876
+#: src/lifesim_lib/const.py:2885
 msgid "The Exorcist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2877
+#: src/lifesim_lib/const.py:2886
 msgid "The Fate of the Furious"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2878
+#: src/lifesim_lib/const.py:2887
 msgid "The Four Horsemen of the Apocalypse"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2879
+#: src/lifesim_lib/const.py:2888
 msgid "The French Connection"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2880
+#: src/lifesim_lib/const.py:2889
 msgid "The Godfather"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2881
+#: src/lifesim_lib/const.py:2890
 msgid "The Godfather: Part II"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2882
+#: src/lifesim_lib/const.py:2891
 msgid "The Godfather: Part III"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2883
+#: src/lifesim_lib/const.py:2892
 msgid "The Graduate"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2884
+#: src/lifesim_lib/const.py:2893
 msgid "The Greatest Show on Earth"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2885
+#: src/lifesim_lib/const.py:2894
 msgid "The Hobbit: An Unexpected Journey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2886
+#: src/lifesim_lib/const.py:2895
 msgid "The Jungle Book"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2887
+#: src/lifesim_lib/const.py:2896
 msgid "The Lion King"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2888
+#: src/lifesim_lib/const.py:2897
 msgid "The Longest Day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2889
+#: src/lifesim_lib/const.py:2898
 msgid "The Lord of the Rings: The Return of the King"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2890
+#: src/lifesim_lib/const.py:2899
 msgid "The Lord of the Rings: The Two Towers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2891
+#: src/lifesim_lib/const.py:2900
 msgid "The Merry Widow"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2892
+#: src/lifesim_lib/const.py:2901
 msgid "The Miracle Man"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2893
+#: src/lifesim_lib/const.py:2902
 msgid "The Red Shoes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2894
+#: src/lifesim_lib/const.py:2903
 msgid "The Robe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2895
+#: src/lifesim_lib/const.py:2904
 msgid "The Sea Hawk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2896
+#: src/lifesim_lib/const.py:2905
 msgid "The Sign of the Cross"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2897
+#: src/lifesim_lib/const.py:2906
 msgid "The Singing Fool"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2898
+#: src/lifesim_lib/const.py:2907
 msgid "The Snake Pit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2899
+#: src/lifesim_lib/const.py:2908
 msgid "The Sound of Music"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2900
+#: src/lifesim_lib/const.py:2909
 msgid "The Sting"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2901
+#: src/lifesim_lib/const.py:2910
 msgid "The Ten Commandments"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2902
+#: src/lifesim_lib/const.py:2911
 msgid "The Towering Inferno"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2903
+#: src/lifesim_lib/const.py:2912
 msgid "This Is Cinerama"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2904
+#: src/lifesim_lib/const.py:2913
 msgid "This Is the Army"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2905
+#: src/lifesim_lib/const.py:2914
 msgid "Titanic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2906
+#: src/lifesim_lib/const.py:2915
 msgid "Top Gun"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2907
+#: src/lifesim_lib/const.py:2916
 msgid "Top Gun: Maverick"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2908
+#: src/lifesim_lib/const.py:2917
 msgid "Toy Story"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2909
+#: src/lifesim_lib/const.py:2918
 msgid "Toy Story 3"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2910
+#: src/lifesim_lib/const.py:2919
 msgid "Toy Story 4"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2911
+#: src/lifesim_lib/const.py:2920
 msgid "Transformers: Age of Extinction"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2912
+#: src/lifesim_lib/const.py:2921
 msgid "Transformers: Dark of the Moon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2913
+#: src/lifesim_lib/const.py:2922
 msgid "Unconquered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2914
+#: src/lifesim_lib/const.py:2923
 msgid "Way Down East"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2915
+#: src/lifesim_lib/const.py:2924
 msgid "West Side Story"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2916
+#: src/lifesim_lib/const.py:2925
 msgid "White Christmas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2917
+#: src/lifesim_lib/const.py:2926
 msgid "Who's Afraid of Virginia Woolf?"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2918
+#: src/lifesim_lib/const.py:2927
 msgid "Wings"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2919
+#: src/lifesim_lib/const.py:2928
 msgid "You Can't Take It With You"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2920
+#: src/lifesim_lib/const.py:2929
 msgid "Zootopia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2923
+#: src/lifesim_lib/const.py:2932
 msgid "Big Boy's Little Adventure"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2930
+#: src/lifesim_lib/const.py:2939
 msgid "Big Hero 6, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2931
+#: src/lifesim_lib/const.py:2940
 msgid "Brave, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2932 src/lifesim_lib/const.py:3021
+#: src/lifesim_lib/const.py:2941 src/lifesim_lib/const.py:3030
 msgid "Cars 2, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2933 src/lifesim_lib/const.py:3077
+#: src/lifesim_lib/const.py:2942 src/lifesim_lib/const.py:3086
 msgid "Coco, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2934 src/lifesim_lib/const.py:3024
+#: src/lifesim_lib/const.py:2943 src/lifesim_lib/const.py:3033
 msgid "Despicable Me, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2935 src/lifesim_lib/const.py:3025
+#: src/lifesim_lib/const.py:2944 src/lifesim_lib/const.py:3034
 msgid "Despicable Me 2, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2936 src/lifesim_lib/const.py:3026
+#: src/lifesim_lib/const.py:2945 src/lifesim_lib/const.py:3035
 msgid "Despicable Me 3, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2937
+#: src/lifesim_lib/const.py:2946
 msgid "Finding Dory, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2938
+#: src/lifesim_lib/const.py:2947
 msgid "Finding Nemo, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2939 src/lifesim_lib/const.py:3081
-#: src/lifesim_lib/const.py:3192
+#: src/lifesim_lib/const.py:2948 src/lifesim_lib/const.py:3090
+#: src/lifesim_lib/const.py:3201
 msgid "Frozen, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2940 src/lifesim_lib/const.py:3082
-#: src/lifesim_lib/const.py:3191
+#: src/lifesim_lib/const.py:2949 src/lifesim_lib/const.py:3091
+#: src/lifesim_lib/const.py:3200
 msgid "Frozen II, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2941 src/lifesim_lib/const.py:3032
+#: src/lifesim_lib/const.py:2950 src/lifesim_lib/const.py:3041
 msgid "Hotel Transylvania 3: Summer Vacation, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2942 src/lifesim_lib/const.py:3092
+#: src/lifesim_lib/const.py:2951 src/lifesim_lib/const.py:3101
 msgid "How to Train Your Dragon 2, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2943
+#: src/lifesim_lib/const.py:2952
 msgid "How to Train Your Dragon: The Hidden World, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2944
+#: src/lifesim_lib/const.py:2953
 msgid "Ice Age: Continental Drift, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2945
+#: src/lifesim_lib/const.py:2954
 msgid "Ice Age: Dawn of the Dinosaurs, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2946
+#: src/lifesim_lib/const.py:2955
 msgid "Ice Age: The Meltdown, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2947 src/lifesim_lib/const.py:3033
+#: src/lifesim_lib/const.py:2956 src/lifesim_lib/const.py:3042
 msgid "Incredibles 2, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2948 src/lifesim_lib/const.py:3034
+#: src/lifesim_lib/const.py:2957 src/lifesim_lib/const.py:3043
 msgid "Inside Out, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2949
+#: src/lifesim_lib/const.py:2958
 msgid "Kung Fu Panda, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2950
+#: src/lifesim_lib/const.py:2959
 msgid "Kung Fu Panda 2, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2951 src/lifesim_lib/const.py:3035
+#: src/lifesim_lib/const.py:2960 src/lifesim_lib/const.py:3044
 msgid "Madagascar, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2952 src/lifesim_lib/const.py:3036
+#: src/lifesim_lib/const.py:2961 src/lifesim_lib/const.py:3045
 msgid "Madagascar 3: Europe's Most Wanted, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2953 src/lifesim_lib/const.py:3037
+#: src/lifesim_lib/const.py:2962 src/lifesim_lib/const.py:3046
 msgid "Madagascar: Escape 2 Africa, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2954 src/lifesim_lib/const.py:3042
+#: src/lifesim_lib/const.py:2963 src/lifesim_lib/const.py:3051
 msgid "Minions, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2955
+#: src/lifesim_lib/const.py:2964
 msgid "Minions: The Rise of Gru , from 2022"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2956 src/lifesim_lib/const.py:3203
+#: src/lifesim_lib/const.py:2965 src/lifesim_lib/const.py:3212
 msgid "Moana, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2957 src/lifesim_lib/const.py:3043
+#: src/lifesim_lib/const.py:2966 src/lifesim_lib/const.py:3052
 msgid "Monsters University, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2958 src/lifesim_lib/const.py:3044
+#: src/lifesim_lib/const.py:2967 src/lifesim_lib/const.py:3053
 msgid "Monsters, Inc., from 2001"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2959
+#: src/lifesim_lib/const.py:2968
 msgid "Ne Zha, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2960 src/lifesim_lib/const.py:3046
+#: src/lifesim_lib/const.py:2969 src/lifesim_lib/const.py:3055
 msgid "Puss in Boots, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2961 src/lifesim_lib/const.py:3047
+#: src/lifesim_lib/const.py:2970 src/lifesim_lib/const.py:3056
 msgid "Ralph Breaks the Internet, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2962 src/lifesim_lib/const.py:3048
+#: src/lifesim_lib/const.py:2971 src/lifesim_lib/const.py:3057
 msgid "Ratatouille, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2963 src/lifesim_lib/const.py:3051
-#: src/lifesim_lib/const.py:3105
+#: src/lifesim_lib/const.py:2972 src/lifesim_lib/const.py:3060
+#: src/lifesim_lib/const.py:3114
 msgid "Shrek 2, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2964 src/lifesim_lib/const.py:3052
-#: src/lifesim_lib/const.py:3106
+#: src/lifesim_lib/const.py:2973 src/lifesim_lib/const.py:3061
+#: src/lifesim_lib/const.py:3115
 msgid "Shrek Forever After, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2965 src/lifesim_lib/const.py:3053
-#: src/lifesim_lib/const.py:3107
+#: src/lifesim_lib/const.py:2974 src/lifesim_lib/const.py:3062
+#: src/lifesim_lib/const.py:3116
 msgid "Shrek the Third, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2966 src/lifesim_lib/const.py:3210
+#: src/lifesim_lib/const.py:2975 src/lifesim_lib/const.py:3219
 msgid "Sing, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2967 src/lifesim_lib/const.py:3054
-#: src/lifesim_lib/const.py:3213
+#: src/lifesim_lib/const.py:2976 src/lifesim_lib/const.py:3063
+#: src/lifesim_lib/const.py:3222
 msgid "Tangled, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2968
+#: src/lifesim_lib/const.py:2977
 msgid "The Boss Baby, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2969
+#: src/lifesim_lib/const.py:2978
 msgid "The Croods, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2970 src/lifesim_lib/const.py:3058
+#: src/lifesim_lib/const.py:2979 src/lifesim_lib/const.py:3067
 msgid "The Incredibles, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2971
+#: src/lifesim_lib/const.py:2980
 msgid "The Lion King , from 1994"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2972
+#: src/lifesim_lib/const.py:2981
 msgid "The Lion King , from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2973 src/lifesim_lib/const.py:3062
+#: src/lifesim_lib/const.py:2982 src/lifesim_lib/const.py:3071
 msgid "The Secret Life of Pets, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2974 src/lifesim_lib/const.py:3064
+#: src/lifesim_lib/const.py:2983 src/lifesim_lib/const.py:3073
 msgid "The Simpsons Movie, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2975 src/lifesim_lib/const.py:3066
+#: src/lifesim_lib/const.py:2984 src/lifesim_lib/const.py:3075
 msgid "Toy Story 3, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2976 src/lifesim_lib/const.py:3067
+#: src/lifesim_lib/const.py:2985 src/lifesim_lib/const.py:3076
 msgid "Toy Story 4, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2977 src/lifesim_lib/const.py:3120
+#: src/lifesim_lib/const.py:2986 src/lifesim_lib/const.py:3129
 msgid "Up, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2978 src/lifesim_lib/const.py:3372
+#: src/lifesim_lib/const.py:2987 src/lifesim_lib/const.py:3381
 msgid "WALL-E, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2979
+#: src/lifesim_lib/const.py:2988
 msgid "Zootopia, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2982
+#: src/lifesim_lib/const.py:2991
 msgid "A Bad Moms Christmas, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2983
+#: src/lifesim_lib/const.py:2992
 msgid "A Christmas Carol, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2984
+#: src/lifesim_lib/const.py:2993
 msgid "A Madea Christmas, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2985
+#: src/lifesim_lib/const.py:2994
 msgid "Almost Christmas, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2986
+#: src/lifesim_lib/const.py:2995
 msgid "Arthur Christmas, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2987
+#: src/lifesim_lib/const.py:2996
 msgid "Bad Santa, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2988
+#: src/lifesim_lib/const.py:2997
 msgid "Christmas with the Kranks, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2989
+#: src/lifesim_lib/const.py:2998
 msgid "Daddy's Home 2, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2990
+#: src/lifesim_lib/const.py:2999
 msgid "Deck the Halls, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2991
+#: src/lifesim_lib/const.py:3000
 msgid "Dr. Seuss' How the Grinch Stole Christmas!, from 2000"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2992
+#: src/lifesim_lib/const.py:3001
 msgid "Elf, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2993
+#: src/lifesim_lib/const.py:3002
 msgid "Four Christmases, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2994
+#: src/lifesim_lib/const.py:3003
 msgid "Fred Claus, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2995 src/lifesim_lib/const.py:3030
+#: src/lifesim_lib/const.py:3004 src/lifesim_lib/const.py:3039
 msgid "Home Alone, from 1990"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2996
+#: src/lifesim_lib/const.py:3005
 msgid "Home Alone 2: Lost in New York, from 1992"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2997
+#: src/lifesim_lib/const.py:3006
 msgid "Jingle All the Way, from 1996"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2998
+#: src/lifesim_lib/const.py:3007
 msgid "Krampus, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:2999
+#: src/lifesim_lib/const.py:3008
 msgid "Last Christmas, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3000
+#: src/lifesim_lib/const.py:3009
 msgid "Love Actually, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3001
+#: src/lifesim_lib/const.py:3010
 msgid "Love the Coopers, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3002
+#: src/lifesim_lib/const.py:3011
 msgid "Miracle on 34th Street, from 1994"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3003
+#: src/lifesim_lib/const.py:3012
 msgid "National Lampoon's Christmas Vacation, from 1989"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3004
+#: src/lifesim_lib/const.py:3013
 msgid "Office Christmas Party, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3005
+#: src/lifesim_lib/const.py:3014
 msgid "Scrooged, from 1988"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3006
+#: src/lifesim_lib/const.py:3015
 msgid "The Best Man Holiday, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3007
+#: src/lifesim_lib/const.py:3016
 msgid "The Grinch, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3008
+#: src/lifesim_lib/const.py:3017
 msgid "The Holiday, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3009
+#: src/lifesim_lib/const.py:3018
 msgid "The Nightmare Before Christmas, from 1993"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3010
+#: src/lifesim_lib/const.py:3019
 msgid "The Nutcracker and the Four Realms, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3011 src/lifesim_lib/const.py:3222
+#: src/lifesim_lib/const.py:3020 src/lifesim_lib/const.py:3231
 msgid "The Polar Express, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3012
+#: src/lifesim_lib/const.py:3021
 msgid "The Santa Clause, from 1994"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3013
+#: src/lifesim_lib/const.py:3022
 msgid "The Santa Clause 2, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3014
+#: src/lifesim_lib/const.py:3023
 msgid "The Santa Clause 3: The Escape Clause, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3015
+#: src/lifesim_lib/const.py:3024
 msgid "The Star, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3016
+#: src/lifesim_lib/const.py:3025
 msgid "This Christmas, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3019
+#: src/lifesim_lib/const.py:3028
 msgid "Bruce Almighty, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3020
+#: src/lifesim_lib/const.py:3029
 msgid "Cars, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3022
+#: src/lifesim_lib/const.py:3031
 msgid "Deadpool, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3023
+#: src/lifesim_lib/const.py:3032
 msgid "Deadpool 2, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3027
+#: src/lifesim_lib/const.py:3036
 msgid "Detective Chinatown 2, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3028
+#: src/lifesim_lib/const.py:3037
 msgid "Detective Chinatown 3, from 2021"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3029
+#: src/lifesim_lib/const.py:3038
 msgid "Hi, Mom, from 2021"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3031
+#: src/lifesim_lib/const.py:3040
 msgid "Hotel Transylvania 2, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3038
+#: src/lifesim_lib/const.py:3047
 msgid "Meet the Fockers, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3039 src/lifesim_lib/const.py:3341
+#: src/lifesim_lib/const.py:3048 src/lifesim_lib/const.py:3350
 msgid "Men in Black, from 1997"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3040 src/lifesim_lib/const.py:3342
+#: src/lifesim_lib/const.py:3049 src/lifesim_lib/const.py:3351
 msgid "Men in Black 3, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3041
+#: src/lifesim_lib/const.py:3050
 msgid "Men in Black II, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3045
+#: src/lifesim_lib/const.py:3054
 msgid "Mrs. Doubtfire, from 1993"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3049
+#: src/lifesim_lib/const.py:3058
 msgid "Sex and the City, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3050
+#: src/lifesim_lib/const.py:3059
 msgid "Shrek, from 2001"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3055
+#: src/lifesim_lib/const.py:3064
 msgid "Ted, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3056
+#: src/lifesim_lib/const.py:3065
 msgid "The Hangover, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3057
+#: src/lifesim_lib/const.py:3066
 msgid "The Hangover Part II, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3059
+#: src/lifesim_lib/const.py:3068
 msgid "The Intouchables, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3060
+#: src/lifesim_lib/const.py:3069
 msgid "The Lego Movie, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3061
+#: src/lifesim_lib/const.py:3070
 msgid "The Mermaid, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3063
+#: src/lifesim_lib/const.py:3072
 msgid "The Secret Life of Pets 2, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3065
+#: src/lifesim_lib/const.py:3074
 msgid "Toy Story 2, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3068
+#: src/lifesim_lib/const.py:3077
 msgid "Wreck-It Ralph, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3071 src/lifesim_lib/const.py:3177
+#: src/lifesim_lib/const.py:3080 src/lifesim_lib/const.py:3186
 msgid "Aladdin, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3072 src/lifesim_lib/const.py:3178
+#: src/lifesim_lib/const.py:3081 src/lifesim_lib/const.py:3187
 msgid "Aladdin, from 1992"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3073
+#: src/lifesim_lib/const.py:3082
 msgid "Alice in Wonderland, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3074 src/lifesim_lib/const.py:3183
+#: src/lifesim_lib/const.py:3083 src/lifesim_lib/const.py:3192
 msgid "Beauty and the Beast, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3075
+#: src/lifesim_lib/const.py:3084
 msgid "Cinderella, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3076
+#: src/lifesim_lib/const.py:3085
 msgid "Clash of the Titans, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3078
+#: src/lifesim_lib/const.py:3087
 msgid "Demon Slayer: Kimetsu no Yaiba the Movie: Mugen Train, from 2020"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3079
+#: src/lifesim_lib/const.py:3088
 msgid "Fantastic Beasts and Where to Find Them, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3080
+#: src/lifesim_lib/const.py:3089
 msgid "Fantastic Beasts: The Crimes of Grindelwald, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3083
+#: src/lifesim_lib/const.py:3092
 msgid "Harry Potter and the Chamber of Secrets, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3084
+#: src/lifesim_lib/const.py:3093
 msgid "Harry Potter and the Deathly Hallows – Part 1, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3085
+#: src/lifesim_lib/const.py:3094
 msgid "Harry Potter and the Deathly Hallows – Part 2, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3086
+#: src/lifesim_lib/const.py:3095
 msgid "Harry Potter and the Goblet of Fire, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3087
+#: src/lifesim_lib/const.py:3096
 msgid "Harry Potter and the Half-Blood Prince, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3088
+#: src/lifesim_lib/const.py:3097
 msgid "Harry Potter and the Order of the Phoenix, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3089
+#: src/lifesim_lib/const.py:3098
 msgid "Harry Potter and the Philosopher's Stone, from 2001"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3090
+#: src/lifesim_lib/const.py:3099
 msgid "Harry Potter and the Prisoner of Azkaban, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3091
+#: src/lifesim_lib/const.py:3100
 msgid "How to Train Your Dragon, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3093
+#: src/lifesim_lib/const.py:3102
 msgid "Indiana Jones and the Last Crusade, from 1989"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3094
+#: src/lifesim_lib/const.py:3103
 msgid "Jumanji: The Next Level, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3095
+#: src/lifesim_lib/const.py:3104
 msgid "Jumanji: Welcome to the Jungle, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3096
+#: src/lifesim_lib/const.py:3105
 msgid "Maleficent, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3097
+#: src/lifesim_lib/const.py:3106
 msgid "Maleficent: Mistress of Evil, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3098
+#: src/lifesim_lib/const.py:3107
 msgid "Night at the Museum, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3099
+#: src/lifesim_lib/const.py:3108
 msgid "Oz the Great and Powerful, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3100
+#: src/lifesim_lib/const.py:3109
 msgid "Pirates of the Caribbean: At World's End, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3101
+#: src/lifesim_lib/const.py:3110
 msgid "Pirates of the Caribbean: Dead Man's Chest, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3102
+#: src/lifesim_lib/const.py:3111
 msgid "Pirates of the Caribbean: Dead Men Tell No Tales, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3103
+#: src/lifesim_lib/const.py:3112
 msgid "Pirates of the Caribbean: On Stranger Tides, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3104
+#: src/lifesim_lib/const.py:3113
 msgid "Pirates of the Caribbean: The Curse of the Black Pearl, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3108
+#: src/lifesim_lib/const.py:3117
 msgid "The Chronicles of Narnia: The Lion, the Witch and the Wardrobe, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3109
+#: src/lifesim_lib/const.py:3118
 msgid "The Hobbit: An Unexpected Journey, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3110
+#: src/lifesim_lib/const.py:3119
 msgid "The Hobbit: The Battle of the Five Armies, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3111
+#: src/lifesim_lib/const.py:3120
 msgid "The Hobbit: The Desolation of Smaug, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3112 src/lifesim_lib/const.py:3217
+#: src/lifesim_lib/const.py:3121 src/lifesim_lib/const.py:3226
 msgid "The Jungle Book, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3113
+#: src/lifesim_lib/const.py:3122
 msgid "The Lord of the Rings: The Fellowship of the Ring, from 2001"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3114
+#: src/lifesim_lib/const.py:3123
 msgid "The Lord of the Rings: The Return of the King, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3115
+#: src/lifesim_lib/const.py:3124
 msgid "The Lord of the Rings: The Two Towers, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3116
+#: src/lifesim_lib/const.py:3125
 msgid "The Twilight Saga: Breaking Dawn – Part 1, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3117
+#: src/lifesim_lib/const.py:3126
 msgid "The Twilight Saga: Breaking Dawn – Part 2, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3118
+#: src/lifesim_lib/const.py:3127
 msgid "The Twilight Saga: Eclipse, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3119
+#: src/lifesim_lib/const.py:3128
 msgid "The Twilight Saga: New Moon, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3124
+#: src/lifesim_lib/const.py:3133
 msgid "A Quiet Place, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3125
+#: src/lifesim_lib/const.py:3134
 msgid "A Quiet Place Part II, from 2021"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3126
+#: src/lifesim_lib/const.py:3135
 msgid "Alien: Covenant, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3127
+#: src/lifesim_lib/const.py:3136
 msgid "Annabelle, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3128
+#: src/lifesim_lib/const.py:3137
 msgid "Annabelle Comes Home, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3129
+#: src/lifesim_lib/const.py:3138
 msgid "Annabelle: Creation, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3130
+#: src/lifesim_lib/const.py:3139
 msgid "Bram Stoker's Dracula, from 1992"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3131
+#: src/lifesim_lib/const.py:3140
 msgid "Constantine, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3132
+#: src/lifesim_lib/const.py:3141
 msgid "Dark Shadows, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3133
+#: src/lifesim_lib/const.py:3142
 msgid "Get Out, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3134
+#: src/lifesim_lib/const.py:3143
 msgid "Glass, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3135
+#: src/lifesim_lib/const.py:3144
 msgid "Halloween, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3136
+#: src/lifesim_lib/const.py:3145
 msgid "Hannibal, from 2001"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3137 src/lifesim_lib/const.py:3333
+#: src/lifesim_lib/const.py:3146 src/lifesim_lib/const.py:3342
 msgid "I Am Legend, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3138
+#: src/lifesim_lib/const.py:3147
 msgid "Interview with the Vampire, from 1994"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3139
+#: src/lifesim_lib/const.py:3148
 msgid "It, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3140
+#: src/lifesim_lib/const.py:3149
 msgid "It Chapter Two, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3141
+#: src/lifesim_lib/const.py:3150
 msgid "Jaws, from 1975"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3142
+#: src/lifesim_lib/const.py:3151
 msgid "Jaws 2, from 1978"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3143
+#: src/lifesim_lib/const.py:3152
 msgid "Paranormal Activity 3, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3144
+#: src/lifesim_lib/const.py:3153
 msgid "Prometheus, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3145
+#: src/lifesim_lib/const.py:3154
 msgid "Resident Evil: Afterlife, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3146
+#: src/lifesim_lib/const.py:3155
 msgid "Resident Evil: Retribution, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3147
+#: src/lifesim_lib/const.py:3156
 msgid "Resident Evil: The Final Chapter, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3148
+#: src/lifesim_lib/const.py:3157
 msgid "Scary Movie, from 2000"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3149
+#: src/lifesim_lib/const.py:3158
 msgid "Shutter Island, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3150
+#: src/lifesim_lib/const.py:3159
 msgid "Signs, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3151
+#: src/lifesim_lib/const.py:3160
 msgid "Sleepy Hollow, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3152
+#: src/lifesim_lib/const.py:3161
 msgid "Split, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3153
+#: src/lifesim_lib/const.py:3162
 msgid "The Blair Witch Project, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3154
+#: src/lifesim_lib/const.py:3163
 msgid "The Conjuring, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3155
+#: src/lifesim_lib/const.py:3164
 msgid "The Conjuring 2, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3156
+#: src/lifesim_lib/const.py:3165
 msgid "The Conjuring: The Devil Made Me Do It, from 2021"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3157
+#: src/lifesim_lib/const.py:3166
 msgid "The Exorcist, from 1973"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3158
+#: src/lifesim_lib/const.py:3167
 msgid "The Meg, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3159
+#: src/lifesim_lib/const.py:3168
 msgid "The Mummy, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3160
+#: src/lifesim_lib/const.py:3169
 msgid "The Mummy, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3161
+#: src/lifesim_lib/const.py:3170
 msgid "The Mummy Returns, from 2001"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3162
+#: src/lifesim_lib/const.py:3171
 msgid "The Mummy: Tomb of the Dragon Emperor, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3163
+#: src/lifesim_lib/const.py:3172
 msgid "The Nun, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3164
+#: src/lifesim_lib/const.py:3173
 msgid "The Others, from 2001"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3165
+#: src/lifesim_lib/const.py:3174
 msgid "The Ring, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3166
+#: src/lifesim_lib/const.py:3175
 msgid "The Silence of the Lambs, from 1991"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3167
+#: src/lifesim_lib/const.py:3176
 msgid "The Sixth Sense, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3168
+#: src/lifesim_lib/const.py:3177
 msgid "The Village, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3169
+#: src/lifesim_lib/const.py:3178
 msgid "Unbreakable, from 2000"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3170
+#: src/lifesim_lib/const.py:3179
 msgid "Us, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3171
+#: src/lifesim_lib/const.py:3180
 msgid "Van Helsing, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3172 src/lifesim_lib/const.py:3374
+#: src/lifesim_lib/const.py:3181 src/lifesim_lib/const.py:3383
 msgid "War of the Worlds, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3173
+#: src/lifesim_lib/const.py:3182
 msgid "World War Z, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3176
+#: src/lifesim_lib/const.py:3185
 msgid "A Star Is Born, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3179
+#: src/lifesim_lib/const.py:3188
 msgid "Alvin and the Chipmunks, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3180
+#: src/lifesim_lib/const.py:3189
 msgid "Alvin and the Chipmunks: Chipwrecked, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3181
+#: src/lifesim_lib/const.py:3190
 msgid "Alvin and the Chipmunks: The Squeakquel, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3182
+#: src/lifesim_lib/const.py:3191
 msgid "Baahubali 2: The Conclusion, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3184
+#: src/lifesim_lib/const.py:3193
 msgid "Beauty and the Beast, from 1991"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3185
+#: src/lifesim_lib/const.py:3194
 msgid "Bohemian Rhapsody, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3186
+#: src/lifesim_lib/const.py:3195
 msgid "Charlie and the Chocolate Factory, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3187
+#: src/lifesim_lib/const.py:3196
 msgid "Chicago, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3188
+#: src/lifesim_lib/const.py:3197
 msgid "Cinderella, from 1950"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3189
+#: src/lifesim_lib/const.py:3198
 msgid "Encanto, from 2021"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3190
+#: src/lifesim_lib/const.py:3199
 msgid "Enchanted, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3193
+#: src/lifesim_lib/const.py:3202
 msgid "Grease, from 1978"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3194
+#: src/lifesim_lib/const.py:3203
 msgid "Happy Feet, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3195
+#: src/lifesim_lib/const.py:3204
 msgid "Hercules, from 1997"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3196
+#: src/lifesim_lib/const.py:3205
 msgid "High School Musical 3: Senior Year, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3197
+#: src/lifesim_lib/const.py:3206
 msgid "Home, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3198
+#: src/lifesim_lib/const.py:3207
 msgid "La La Land, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3199
+#: src/lifesim_lib/const.py:3208
 msgid "Les Misérables, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3200
+#: src/lifesim_lib/const.py:3209
 msgid "Mamma Mia: Here We Go Again!, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3201
+#: src/lifesim_lib/const.py:3210
 msgid "Mamma Mia!, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3202
+#: src/lifesim_lib/const.py:3211
 msgid "Mary Poppins Returns, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3204
+#: src/lifesim_lib/const.py:3213
 msgid "Mulan, from 1998"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3205
+#: src/lifesim_lib/const.py:3214
 msgid "Pitch Perfect 2, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3206
+#: src/lifesim_lib/const.py:3215
 msgid "Pocahontas, from 1995"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3207
+#: src/lifesim_lib/const.py:3216
 msgid "Rio, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3208
+#: src/lifesim_lib/const.py:3217
 msgid "Rio 2, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3209
+#: src/lifesim_lib/const.py:3218
 msgid "Saturday Night Fever, from 1977"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3211
+#: src/lifesim_lib/const.py:3220
 msgid "Sing 2, from 2021"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3212
+#: src/lifesim_lib/const.py:3221
 msgid "Snow White and the Seven Dwarfs, from 1937"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3214
+#: src/lifesim_lib/const.py:3223
 msgid "Tarzan, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3215
+#: src/lifesim_lib/const.py:3224
 msgid "The Greatest Showman, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3216
+#: src/lifesim_lib/const.py:3225
 msgid "The Hunchback of Notre Dame, from 1996"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3218
+#: src/lifesim_lib/const.py:3227
 msgid "The Jungle Book, from 1967"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3219
+#: src/lifesim_lib/const.py:3228
 msgid "The Lion King, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3220
+#: src/lifesim_lib/const.py:3229
 msgid "The Lion King, from 1994"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3221
+#: src/lifesim_lib/const.py:3230
 msgid "The Lorax, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3223
+#: src/lifesim_lib/const.py:3232
 msgid "The Princess and the Frog, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3224
+#: src/lifesim_lib/const.py:3233
 msgid "The Sound of Music, from 1965"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3225
+#: src/lifesim_lib/const.py:3234
 msgid "Trolls, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3228
+#: src/lifesim_lib/const.py:3237
 msgid "9 Lives of a Wet Pussy, from 1976. It starred Pauline LaMonde and was about the erotic escapades of a young New York heiress"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3231
+#: src/lifesim_lib/const.py:3240
 msgid "A Dirty Western, from 1975"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3232
+#: src/lifesim_lib/const.py:3241
 msgid "A Perfect Ending, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3233
+#: src/lifesim_lib/const.py:3242
 msgid "A Taste of Joy, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3234
+#: src/lifesim_lib/const.py:3243
 msgid "Alice in Wonderland: An X-Rated Musical Comedy, from 1976"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3235
+#: src/lifesim_lib/const.py:3244
 msgid "Animal Instincts, from 1992"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3236
+#: src/lifesim_lib/const.py:3245
 msgid "Aphrodesia's Diary, from 1983"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3237
+#: src/lifesim_lib/const.py:3246
 msgid "Babylon Pink, from 1979. It starred several leads and was about the sexual fantasies of several women; a bored housewife, a business woman, an older woman, and a sexually curious teenager"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3240
+#: src/lifesim_lib/const.py:3249
 msgid "Barbara Broadcast, from 1977"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3241
+#: src/lifesim_lib/const.py:3250
 msgid "Behind the Green Door, from 1972"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3242
+#: src/lifesim_lib/const.py:3251
 msgid "Bend Over Boyfriend, from 1998"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3243
+#: src/lifesim_lib/const.py:3252
 msgid "Bijou, from 1972. It starred Bill Harrison and was a gay film about a construction worker discovering an invitation to a sex club"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3246
+#: src/lifesim_lib/const.py:3255
 msgid "Black Emmanuelle, from 1975"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3247
+#: src/lifesim_lib/const.py:3256
 msgid "Blue Movie, from 1969. It was directed by Andy Warhol and starred Viva, and Louis Waldon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3250
+#: src/lifesim_lib/const.py:3259
 msgid "Bound, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3251
+#: src/lifesim_lib/const.py:3260
 msgid "Cabaret Desire, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3252
+#: src/lifesim_lib/const.py:3261
 msgid "Chemistry, from 2006"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3253
+#: src/lifesim_lib/const.py:3262
 msgid "Dangerous Liaisons, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3254
+#: src/lifesim_lib/const.py:3263
 msgid "Debbie Does Dallas, from 1978"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3255
+#: src/lifesim_lib/const.py:3264
 msgid "Deep Throat, from 1972"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3256
+#: src/lifesim_lib/const.py:3265
 msgid "El Paso Wrecking Corp., from 1978"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3257
+#: src/lifesim_lib/const.py:3266
 msgid "Emmanuelle, from 1974"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3258
+#: src/lifesim_lib/const.py:3267
 msgid "Flashpoint, from 1998"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3259
+#: src/lifesim_lib/const.py:3268
 msgid "Flesh Gordon, from 1974"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3260
+#: src/lifesim_lib/const.py:3269
 msgid "Harlot, from 1971"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3261
+#: src/lifesim_lib/const.py:3270
 msgid "High Test Girls, from 1980"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3262
+#: src/lifesim_lib/const.py:3271
 msgid "Hotel Erotica, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3263
+#: src/lifesim_lib/const.py:3272
 msgid "Insatiable, from 1980"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3264
+#: src/lifesim_lib/const.py:3273
 msgid "I am Curious (Blue), from 1968"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3265
+#: src/lifesim_lib/const.py:3274
 msgid "I am Curious (Yellow), from 1967"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3266
+#: src/lifesim_lib/const.py:3275
 msgid "Infidelity: Sex Stories 2, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3267
+#: src/lifesim_lib/const.py:3276
 msgid "Last Tango, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3268
+#: src/lifesim_lib/const.py:3277
 msgid "Love Toy, from 1968"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3269
+#: src/lifesim_lib/const.py:3278
 msgid "Maraschino Cherry, from 1978"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3270
+#: src/lifesim_lib/const.py:3279
 msgid "Missing: A Lesbian Crime Story, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3271
+#: src/lifesim_lib/const.py:3280
 msgid "Mona the Virgin Nymph, from 1970"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3272
+#: src/lifesim_lib/const.py:3281
 msgid "Nothing Personal, from 1990. It starred Moana Pozzi and was about a personal quest to improve her sex life"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3275
+#: src/lifesim_lib/const.py:3284
 msgid "Once Upon a Girl, from 1976"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3276
+#: src/lifesim_lib/const.py:3285
 msgid "Perspective, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3277
+#: src/lifesim_lib/const.py:3286
 msgid "Pink Prison, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3278
+#: src/lifesim_lib/const.py:3287
 msgid "Pink Velvet 3: A Lesbian Odyssey, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3279
+#: src/lifesim_lib/const.py:3288
 msgid "Pirates, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3280
+#: src/lifesim_lib/const.py:3289
 msgid "Pirates II: Stagnetti’s Revenge, from 2008"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3281
+#: src/lifesim_lib/const.py:3290
 msgid "Red Shoe Diaries, from 1992"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3282
+#: src/lifesim_lib/const.py:3291
 msgid "Reel People, from 1984. It starred Juliet Anderson and was about real people performing their sexual desires on film for the first time"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3285
+#: src/lifesim_lib/const.py:3294
 msgid "Rendez-vous, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3286
+#: src/lifesim_lib/const.py:3295
 msgid "School Girl, from 1971"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3287
+#: src/lifesim_lib/const.py:3296
 msgid "Score, from 1974"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3288
+#: src/lifesim_lib/const.py:3297
 msgid "Sensational Janine, from 1976"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3289
+#: src/lifesim_lib/const.py:3298
 msgid "Sex Pursuits, from 1971. It starred Rene Bond"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3290
+#: src/lifesim_lib/const.py:3299
 msgid "Sex Stories, from 2009. It starred multiple leads and was about two dinner parties simultaneously unfolding. Each sharing stories of their recent escapades"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3293
+#: src/lifesim_lib/const.py:3302
 msgid "Sexual Chronicles of a French Family, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3294
+#: src/lifesim_lib/const.py:3303
 msgid "Snapshot, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3295
+#: src/lifesim_lib/const.py:3304
 msgid "Taboo, from 1980"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3296
+#: src/lifesim_lib/const.py:3305
 msgid "Taboo II, from 1982"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3297
+#: src/lifesim_lib/const.py:3306
 msgid "The Bare Wench Project, from 2000"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3298
+#: src/lifesim_lib/const.py:3307
 msgid "The Bi Apple, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3299
+#: src/lifesim_lib/const.py:3308
 msgid "The Bite, from 1977"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3300
+#: src/lifesim_lib/const.py:3309
 msgid "The Cheerleaders, from 1973"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3301
+#: src/lifesim_lib/const.py:3310
 msgid "The Devil in Miss Jones, from 1973. It starred Georgina Spelvin and was about a woman who commits suicide. Where, instead of going to Heaven, she returns to life to embody lust"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3304
+#: src/lifesim_lib/const.py:3313
 msgid "The Dreamers, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3305
+#: src/lifesim_lib/const.py:3314
 msgid "The Fashionistas, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3306
+#: src/lifesim_lib/const.py:3315
 msgid "The Friend Zone, from 2012. It starred Riley Reid"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3307
+#: src/lifesim_lib/const.py:3316
 msgid "The Good Girl, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3308
+#: src/lifesim_lib/const.py:3317
 msgid "The Grafenberg Spot, from 1985"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3309
+#: src/lifesim_lib/const.py:3318
 msgid "The Jade Pussycat, from 1977"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3310
+#: src/lifesim_lib/const.py:3319
 msgid "The Obsession, from 2017. It starred Abella Danger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3311
+#: src/lifesim_lib/const.py:3320
 msgid "The Opening of Misty Beethoven, from 1976"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3312
+#: src/lifesim_lib/const.py:3321
 msgid "The Submission of Emma Marx, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3313
+#: src/lifesim_lib/const.py:3322
 msgid "The Ultimate Pleasure, from 1977. It starred Kristine Heller and was about a cab driver who finds a suitcase full of money and realises he now has the means to fulfil all of his wife’s sexual fantasies"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3316
+#: src/lifesim_lib/const.py:3325
 msgid "The Walking Dead: A Hardcore Parody, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3317
+#: src/lifesim_lib/const.py:3326
 msgid "The Xterminator, from 1986"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3318
+#: src/lifesim_lib/const.py:3327
 msgid "Through the Looking Glass, from 1976"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3319
+#: src/lifesim_lib/const.py:3328
 msgid "Tonight for Sure, from 1962"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3320
+#: src/lifesim_lib/const.py:3329
 msgid "Xana and Dax: When Opposites Attract, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3321
+#: src/lifesim_lib/const.py:3330
 msgid "XConfessions Vol. 3, from 2014. It starred Maria Agrado, Samantha Bentley and Samia Duarte, and was a compilation of 10 erotic stories"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3326
+#: src/lifesim_lib/const.py:3335
 msgid "Armageddon, from 1998"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3327
+#: src/lifesim_lib/const.py:3336
 msgid "Avatar, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3328
+#: src/lifesim_lib/const.py:3337
 msgid "Bumblebee, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3329
+#: src/lifesim_lib/const.py:3338
 msgid "Dawn of the Planet of the Apes, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3330
+#: src/lifesim_lib/const.py:3339
 msgid "E.T. the Extra-Terrestrial , from 1982"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3331
+#: src/lifesim_lib/const.py:3340
 msgid "Godzilla, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3332
+#: src/lifesim_lib/const.py:3341
 msgid "Gravity, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3334
+#: src/lifesim_lib/const.py:3343
 msgid "Inception, from 2010"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3335
+#: src/lifesim_lib/const.py:3344
 msgid "Independence Day, from 1996"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3336
+#: src/lifesim_lib/const.py:3345
 msgid "Interstellar, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3337
+#: src/lifesim_lib/const.py:3346
 msgid "Jurassic Park, from 1993"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3338
+#: src/lifesim_lib/const.py:3347
 msgid "Jurassic World, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3339
+#: src/lifesim_lib/const.py:3348
 msgid "Jurassic World Dominion , from 2022"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3340
+#: src/lifesim_lib/const.py:3349
 msgid "Jurassic World: Fallen Kingdom, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3343
+#: src/lifesim_lib/const.py:3352
 msgid "Ready Player One, from 2018"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3344
+#: src/lifesim_lib/const.py:3353
 msgid "Rise of the Planet of the Apes, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3345
+#: src/lifesim_lib/const.py:3354
 msgid "Rogue One: A Star Wars Story, from 2016"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3346
+#: src/lifesim_lib/const.py:3355
 msgid "Star Trek Into Darkness, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3347
+#: src/lifesim_lib/const.py:3356
 msgid "Star Wars, from 1977"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3348
+#: src/lifesim_lib/const.py:3357
 msgid "Star Wars: Episode I – The Phantom Menace, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3349
+#: src/lifesim_lib/const.py:3358
 msgid "Star Wars: Episode II – Attack of the Clones, from 2002"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3350
+#: src/lifesim_lib/const.py:3359
 msgid "Star Wars: Episode III – Revenge of the Sith, from 2005"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3351
+#: src/lifesim_lib/const.py:3360
 msgid "Star Wars: Episode V – The Empire Strikes Back, from 1980"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3352
+#: src/lifesim_lib/const.py:3361
 msgid "Star Wars: Episode VI – Return of the Jedi, from 1983"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3353
+#: src/lifesim_lib/const.py:3362
 msgid "Star Wars: The Force Awakens, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3354
+#: src/lifesim_lib/const.py:3363
 msgid "Star Wars: The Last Jedi, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3355
+#: src/lifesim_lib/const.py:3364
 msgid "Star Wars: The Rise of Skywalker, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3356
+#: src/lifesim_lib/const.py:3365
 msgid "Terminator 2: Judgment Day, from 1991"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3357
+#: src/lifesim_lib/const.py:3366
 msgid "The Day After Tomorrow, from 2004"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3358
+#: src/lifesim_lib/const.py:3367
 msgid "The Hunger Games, from 2012"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3359
+#: src/lifesim_lib/const.py:3368
 msgid "The Hunger Games: Catching Fire, from 2013"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3360
+#: src/lifesim_lib/const.py:3369
 msgid "The Hunger Games: Mockingjay – Part 1, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3361
+#: src/lifesim_lib/const.py:3370
 msgid "The Hunger Games: Mockingjay – Part 2, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3362
+#: src/lifesim_lib/const.py:3371
 msgid "The Lost World: Jurassic Park, from 1997"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3363
+#: src/lifesim_lib/const.py:3372
 msgid "The Martian, from 2015"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3364
+#: src/lifesim_lib/const.py:3373
 msgid "The Matrix, from 1999"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3365
+#: src/lifesim_lib/const.py:3374
 msgid "The Matrix Reloaded, from 2003"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3366
+#: src/lifesim_lib/const.py:3375
 msgid "The Wandering Earth, from 2019"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3367
+#: src/lifesim_lib/const.py:3376
 msgid "Transformers, from 2007"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3368
+#: src/lifesim_lib/const.py:3377
 msgid "Transformers: Age of Extinction, from 2014"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3369
+#: src/lifesim_lib/const.py:3378
 msgid "Transformers: Dark of the Moon, from 2011"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3370
+#: src/lifesim_lib/const.py:3379
 msgid "Transformers: Revenge of the Fallen, from 2009"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3371
+#: src/lifesim_lib/const.py:3380
 msgid "Transformers: The Last Knight, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3373
+#: src/lifesim_lib/const.py:3382
 msgid "War for the Planet of the Apes, from 2017"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3385
+#: src/lifesim_lib/const.py:3394
 msgid "the hierarchy of licorice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3386
+#: src/lifesim_lib/const.py:3395
 msgid "which is better, Star Wars or Star Trek"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3387
+#: src/lifesim_lib/const.py:3396
 msgid "which is better, Coke or Pepsi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3388
+#: src/lifesim_lib/const.py:3397
 msgid "which is better, Lord of the Rings or Harry Potter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3389
+#: src/lifesim_lib/const.py:3398
 msgid "who is better, the Red Sox or Yankees"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3390 src/lifesim_lib/const.py:3676
+#: src/lifesim_lib/const.py:3399 src/lifesim_lib/const.py:3685
 msgid "who will win the Monaco Grand Prix"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3391
+#: src/lifesim_lib/const.py:3400
 msgid "whether you would rather live without music or television"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3392
+#: src/lifesim_lib/const.py:3401
 msgid "Angleina Jolie's lips"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3395
+#: src/lifesim_lib/const.py:3404
 msgid "choo-choo trains, and then both made baby noises at each other"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3396
+#: src/lifesim_lib/const.py:3405
 msgid "why 'A' is for 'Apple'"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3397
+#: src/lifesim_lib/const.py:3406
 msgid "the fluffy pussy cat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3398
+#: src/lifesim_lib/const.py:3407
 msgid "Thomas the Tank Engine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3399
+#: src/lifesim_lib/const.py:3408
 msgid "Dinosaur Train"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3400
+#: src/lifesim_lib/const.py:3409
 msgid "Alphablocks"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3401
+#: src/lifesim_lib/const.py:3410
 msgid "Sesame street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3402
+#: src/lifesim_lib/const.py:3411
 msgid "Mickey Mouse"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3403
+#: src/lifesim_lib/const.py:3412
 msgid "'O' is for 'Owl'"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3404
+#: src/lifesim_lib/const.py:3413
 msgid "'O' is for 'Octopus'"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3405
+#: src/lifesim_lib/const.py:3414
 msgid "'O' is for 'Orange'"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3406
+#: src/lifesim_lib/const.py:3415
 msgid "three blind mice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3409
+#: src/lifesim_lib/const.py:3418
 msgid "how much you hate vegetables"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3410
+#: src/lifesim_lib/const.py:3419
 msgid "how scary the toilet is when it gets flushed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3411
+#: src/lifesim_lib/const.py:3420
 msgid "the meaning of life"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3412
+#: src/lifesim_lib/const.py:3421
 msgid "which super power you would most like to have"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3413
+#: src/lifesim_lib/const.py:3422
 msgid "which super power they would most like to have"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3414
+#: src/lifesim_lib/const.py:3423
 msgid "what they want to be when they grow up"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3415
+#: src/lifesim_lib/const.py:3424
 msgid "where water goes when the toilet gets flushed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3416
+#: src/lifesim_lib/const.py:3425
 msgid "why the sky is blue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3417 src/lifesim_lib/const.py:3665
+#: src/lifesim_lib/const.py:3426 src/lifesim_lib/const.py:3674
 msgid "your favourite movie character"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3418
+#: src/lifesim_lib/const.py:3427
 msgid "your least favourite chore"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3442
+#: src/lifesim_lib/const.py:3451
 msgid "Frida Kahlo's moustache"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3443
+#: src/lifesim_lib/const.py:3452
 msgid "which is the best breed of dog"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3444
+#: src/lifesim_lib/const.py:3453
 msgid "which is the best breed of cat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3445
+#: src/lifesim_lib/const.py:3454
 msgid "why cats are better than dogs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3446
+#: src/lifesim_lib/const.py:3455
 msgid "why dogs are better than cats"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3447
+#: src/lifesim_lib/const.py:3456
 msgid "the Russia-Ukraine War"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3448
+#: src/lifesim_lib/const.py:3457
 msgid "High Fuel Prices"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3449
+#: src/lifesim_lib/const.py:3458
 msgid "the Metaverse"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3450
+#: src/lifesim_lib/const.py:3459
 msgid "the Economic crisis of Sri Lanka"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3451
+#: src/lifesim_lib/const.py:3460
 msgid "Moonlighting"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3452
+#: src/lifesim_lib/const.py:3461
 msgid "the Pros and Cons of working from home"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3453
+#: src/lifesim_lib/const.py:3462
 msgid "whether people should invest in cryptocurrency"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3454
+#: src/lifesim_lib/const.py:3463
 msgid "the Biomedical waste crisis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3455
+#: src/lifesim_lib/const.py:3464
 msgid "the impact of 5G on the global economy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3456
+#: src/lifesim_lib/const.py:3465
 msgid "how to prevent the next pandemic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3457
+#: src/lifesim_lib/const.py:3466
 msgid "the impact of COVID-19 on the global economy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3458
+#: src/lifesim_lib/const.py:3467
 msgid "the pros and cons of block chain technology"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3459
+#: src/lifesim_lib/const.py:3468
 msgid "the role of social media in international politics"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3460
+#: src/lifesim_lib/const.py:3469
 msgid "how to end the threat of nuclear war"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3461
+#: src/lifesim_lib/const.py:3470
 msgid "the impact of COVID-19 on the education sector"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3462
+#: src/lifesim_lib/const.py:3471
 msgid "Taliban rule in Afghanistan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3463
+#: src/lifesim_lib/const.py:3472
 msgid "the rise of the gig economy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3464
+#: src/lifesim_lib/const.py:3473
 msgid "the harms of passive smoking"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3465
+#: src/lifesim_lib/const.py:3474
 msgid "the advantages and disadvantages of having a credit card"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3466
+#: src/lifesim_lib/const.py:3475
 msgid "whether software should be free for everyone"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3467
+#: src/lifesim_lib/const.py:3476
 msgid "whether gambling should be allowed from the age of 16"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3468
+#: src/lifesim_lib/const.py:3477
 msgid "problems caused by the economic boycott in Cuba"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3469
+#: src/lifesim_lib/const.py:3478
 msgid "how international trade barriers work"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3470
+#: src/lifesim_lib/const.py:3479
 msgid "how the United Nations is based on diplomacy and strengthening relationships"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3471
+#: src/lifesim_lib/const.py:3480
 msgid "whether or not public schools are safe enough"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3472
+#: src/lifesim_lib/const.py:3481
 msgid "whether it is necessary to hold value in what you argue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3473
+#: src/lifesim_lib/const.py:3482
 msgid "why drink driving is dangerous"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3474
+#: src/lifesim_lib/const.py:3483
 msgid "how India became such a large milk producer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3475
+#: src/lifesim_lib/const.py:3484
 msgid "how to make money with recycling"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3476
+#: src/lifesim_lib/const.py:3485
 msgid "the decreasing productivity of the Japanese workforce"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3477
+#: src/lifesim_lib/const.py:3486
 msgid "a business model to help health-conscious customers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3478
+#: src/lifesim_lib/const.py:3487
 msgid "what the best technologies are to safeguard the right of free speech on the internet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3481
+#: src/lifesim_lib/const.py:3490
 msgid "what the best technologies are to safeguard the right of privacy on the internet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3484
+#: src/lifesim_lib/const.py:3493
 msgid "how to check for the signs of burnout"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3485
+#: src/lifesim_lib/const.py:3494
 msgid "how to overcome the coal crisis in India"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3486
+#: src/lifesim_lib/const.py:3495
 msgid "the causes of bullying in schools"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3487
+#: src/lifesim_lib/const.py:3496
 msgid "why we should have a minimum wage"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3488
+#: src/lifesim_lib/const.py:3497
 msgid "whether universal basic income is a good idea"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3489
+#: src/lifesim_lib/const.py:3498
 msgid "the leadership changes needed in our country"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3490
+#: src/lifesim_lib/const.py:3499
 msgid "whether empowering women is the solution to violence against women"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3491
+#: src/lifesim_lib/const.py:3500
 msgid "the effects of communalism on social cohesion"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3492
+#: src/lifesim_lib/const.py:3501
 msgid "whether we're becoming too sensitive in society"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3493
+#: src/lifesim_lib/const.py:3502
 msgid "lessons for the world from the COVID-19 pandemic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3494
+#: src/lifesim_lib/const.py:3503
 msgid "whether crime rates increase because of unemployment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3495
+#: src/lifesim_lib/const.py:3504
 msgid "causes of poverty around the world"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3496
+#: src/lifesim_lib/const.py:3505
 msgid "the effects of the Internet of Things on our lives"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3497
+#: src/lifesim_lib/const.py:3506
 msgid "whether drug abuse is rampant among teenagers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3498
+#: src/lifesim_lib/const.py:3507
 msgid "whether anemia effects urban society"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3499
+#: src/lifesim_lib/const.py:3508
 msgid "gender equality in the workplace"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3500
+#: src/lifesim_lib/const.py:3509
 msgid "whether the wealthy should be taxed more"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3501
+#: src/lifesim_lib/const.py:3510
 msgid "whether the poor should be given more assistance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3502
+#: src/lifesim_lib/const.py:3511
 msgid "whether it is possible to maintain a work-life balance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3503
+#: src/lifesim_lib/const.py:3512
 msgid "whether saying 'women make good managers' is sexist like saying 'asians are good at maths' is racist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3506
+#: src/lifesim_lib/const.py:3515
 msgid "whether job creators are needed more than job seekers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3507
+#: src/lifesim_lib/const.py:3516
 msgid "whether a borderless world is a myth or a reality"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3508
+#: src/lifesim_lib/const.py:3517
 msgid "what would happen if Bitcoin crashed to zero and whether it is possible"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3509
+#: src/lifesim_lib/const.py:3518
 msgid "business ethics in today's market compared with the past and the potential future"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3512
+#: src/lifesim_lib/const.py:3521
 msgid "whether patience is important in business and management"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3513
+#: src/lifesim_lib/const.py:3522
 msgid "whether the family-run business is relevant in today's market"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3514
+#: src/lifesim_lib/const.py:3523
 msgid "whether E-commerce discounts are harmful in the long run and is it the business or customer being harmed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3517
+#: src/lifesim_lib/const.py:3526
 msgid "whether globalisation is an opportunity or a threat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3518
+#: src/lifesim_lib/const.py:3527
 msgid "how markets are found and not created"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3519
+#: src/lifesim_lib/const.py:3528
 msgid "whether the world is ready for a cashless society"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3520
+#: src/lifesim_lib/const.py:3529
 msgid "whether physical infrastructure is the answer to social equality"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3521
+#: src/lifesim_lib/const.py:3530
 msgid "whether the public sector being a guarantor of job security is a myth"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3522
+#: src/lifesim_lib/const.py:3531
 msgid "whether a circular economy is key to sustainable development"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3523
+#: src/lifesim_lib/const.py:3532
 msgid "the contribution of the Indian IT industry to the US and global economy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3524
+#: src/lifesim_lib/const.py:3533
 msgid "whether democracy is a hindrance to economic reforms in India"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3525
+#: src/lifesim_lib/const.py:3534
 msgid "the technology behind Zero Budget Natural Farming"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3526
+#: src/lifesim_lib/const.py:3535
 msgid "the effects of technological change on jobs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3527
+#: src/lifesim_lib/const.py:3536
 msgid "whether pervasive technology is creating a generation of cyber zombies"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3528
+#: src/lifesim_lib/const.py:3537
 msgid "whether the IT industry will create more or less jobs in the future"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3529
+#: src/lifesim_lib/const.py:3538
 msgid "whether artificial intelligence can replace human intelligence"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3530
+#: src/lifesim_lib/const.py:3539
 msgid "the effects of big data on information privacy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3531
+#: src/lifesim_lib/const.py:3540
 msgid "whether automation will create more or less jobs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3532
+#: src/lifesim_lib/const.py:3541
 msgid "the benefits and challenges of data localisation"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3533
+#: src/lifesim_lib/const.py:3542
 msgid "whether artifical intelligence will change the future"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3534
+#: src/lifesim_lib/const.py:3543
 msgid "how technology can be used to tackle financial crimes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3535
+#: src/lifesim_lib/const.py:3544
 msgid "whether polythene bags should be completely banned"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3536
+#: src/lifesim_lib/const.py:3545
 msgid "how to control air pollution levels"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3537
+#: src/lifesim_lib/const.py:3546
 msgid "whether green jobs are essential for sustainable development"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3538
+#: src/lifesim_lib/const.py:3547
 msgid "how to manage natural disasters"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3539
+#: src/lifesim_lib/const.py:3548
 msgid "how to manage financial disasters"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3540
+#: src/lifesim_lib/const.py:3549
 msgid "methods of disaster recovery"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3541
+#: src/lifesim_lib/const.py:3550
 msgid "the effects of Coronaviruses on the environment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3542
+#: src/lifesim_lib/const.py:3551
 msgid "whether smart farming is the future of agriculture"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3543
+#: src/lifesim_lib/const.py:3552
 msgid "whether genetic engineering in agriculture is good or bad"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3544
+#: src/lifesim_lib/const.py:3553
 msgid "the effects of climate on the farming system and food supply"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3545
+#: src/lifesim_lib/const.py:3554
 msgid "whether automation in farming is good"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3546
+#: src/lifesim_lib/const.py:3555
 msgid "whether collective farming is a boon or a bane"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3547
+#: src/lifesim_lib/const.py:3556
 msgid "our views on natural versus factory farming"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3548
+#: src/lifesim_lib/const.py:3557
 msgid "our views on conventional farming and organic farming"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3549
+#: src/lifesim_lib/const.py:3558
 msgid "the role of women in agriculture"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3550
+#: src/lifesim_lib/const.py:3559
 msgid "whether agroforestry destroys the environment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3551
+#: src/lifesim_lib/const.py:3560
 msgid "gay marriage and your views on it"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3552
+#: src/lifesim_lib/const.py:3561
 msgid "whether war is the best option to solve international disputes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3553
+#: src/lifesim_lib/const.py:3562
 msgid "whether primary school children should be allowed to own mobile phones"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3554
+#: src/lifesim_lib/const.py:3563
 msgid "whether using animals for medical research should be allowed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3555
+#: src/lifesim_lib/const.py:3564
 msgid "whether men and women will ever be equal, if they already are, and whether equality will last"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3558
+#: src/lifesim_lib/const.py:3567
 msgid "whether you can have a happy family life and a successful career at the same time"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3561
+#: src/lifesim_lib/const.py:3570
 msgid "whether marriage is an outdated institution"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3562
+#: src/lifesim_lib/const.py:3571
 msgid "whether citizens should be allowed to carry guns and other weapons"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3563
+#: src/lifesim_lib/const.py:3572
 msgid "whether the death penalty is acceptable for any reasons"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3564
+#: src/lifesim_lib/const.py:3573
 msgid "whether non-citizens and tourists should be allowed to vote in their country of residence"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3567
+#: src/lifesim_lib/const.py:3576
 msgid "whether sex education should be taught to children under 12"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3568
+#: src/lifesim_lib/const.py:3577
 msgid "whether or not women are paid the same as men"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3569
+#: src/lifesim_lib/const.py:3578
 msgid "whether bribery and corruption is acceptable in government"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3570
+#: src/lifesim_lib/const.py:3579
 msgid "whether bribery and corruption is acceptable in private business"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3571
+#: src/lifesim_lib/const.py:3580
 msgid "whether music that glorifies violence should be banned"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3572
+#: src/lifesim_lib/const.py:3581
 msgid "whether condoms should be distributed for free in primary schools"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3573
+#: src/lifesim_lib/const.py:3582
 msgid "whether nuclear weapons are necessary weapons"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3574
+#: src/lifesim_lib/const.py:3583
 msgid "whether teachers should be allowed to carry guns"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3575
+#: src/lifesim_lib/const.py:3584
 msgid "whether professional sports people earn too much money"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3576
+#: src/lifesim_lib/const.py:3585
 msgid "our views on whether or not beauty contests should be banned"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3577
+#: src/lifesim_lib/const.py:3586
 msgid "our views on whether or not cosmetic surgery should be outlawed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3578
+#: src/lifesim_lib/const.py:3587
 msgid "our views on whether or not abortions are okay"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3579
+#: src/lifesim_lib/const.py:3588
 msgid "our views on whether or not social deprivation causes crime"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3580
+#: src/lifesim_lib/const.py:3589
 msgid "our views on whether or not military service should be compulsory"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3581
+#: src/lifesim_lib/const.py:3590
 msgid "our views on whether or not war is ever an option for solving international disputes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3584
+#: src/lifesim_lib/const.py:3593
 msgid "our views on whether or not torture can be acceptable in some cases"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3585
+#: src/lifesim_lib/const.py:3594
 msgid "our views on whether or not curfews keep teens out of trouble"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3586
+#: src/lifesim_lib/const.py:3595
 msgid "our views on whether or not we're becoming too dependent on computers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3587
+#: src/lifesim_lib/const.py:3596
 msgid "our views on whether or not smoking should be banned worldwide"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3588
+#: src/lifesim_lib/const.py:3597
 msgid "our views on whether or not it should be illegal to ride a bicycle without a helmet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3591
+#: src/lifesim_lib/const.py:3600
 msgid "our views on whether or not single sex schools are bad for childhood development and lead to unhealthy views of the opposite sex"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3594
+#: src/lifesim_lib/const.py:3603
 msgid "our views on whether or not homework is harmful"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3595
+#: src/lifesim_lib/const.py:3604
 msgid "our views on whether or not the United Nations is a failed organisation"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3596
+#: src/lifesim_lib/const.py:3605
 msgid "our views on whether or not intelligence tests should be given before couples can have children"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3599
+#: src/lifesim_lib/const.py:3608
 msgid "our views on whether or not a woman's place is in the home"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3600
+#: src/lifesim_lib/const.py:3609
 msgid "our views on whether or not it's a man's world"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3601
+#: src/lifesim_lib/const.py:3610
 msgid "our views on whether or not money makes you happy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3602
+#: src/lifesim_lib/const.py:3611
 msgid "our views on whether or not money can buy you happiness"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3603
+#: src/lifesim_lib/const.py:3612
 msgid "our views on whether or not the internet must be censored to protect society"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3604
+#: src/lifesim_lib/const.py:3613
 msgid "our views on whether or not genetically modified foods have no ill health effects"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3607
+#: src/lifesim_lib/const.py:3616
 msgid "our views on whether a man should have a wife for the family and a paramour for pleasure"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3610
+#: src/lifesim_lib/const.py:3619
 msgid "our views on whether a woman should have a husband for the family and a paramour for pleasure"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3613
+#: src/lifesim_lib/const.py:3622
 msgid "our views on whether soft drugs should be legalised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3614
+#: src/lifesim_lib/const.py:3623
 msgid "our views on whether or not electric cars help the environment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3615
+#: src/lifesim_lib/const.py:3624
 msgid "our views on whether or not staying unmarried leads to a happier life"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3616
+#: src/lifesim_lib/const.py:3625
 msgid "our views on whether or not software piracy is a real crime"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3617
+#: src/lifesim_lib/const.py:3626
 msgid "our views on whether or not religion is needed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3618
+#: src/lifesim_lib/const.py:3627
 msgid "our views on whether veganism is the key to solving climate change"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3619
+#: src/lifesim_lib/const.py:3628
 msgid "our views on whether the police force is institutionally racist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3620
+#: src/lifesim_lib/const.py:3629
 msgid "our views on whether democracy must be imposed on nations"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3621
+#: src/lifesim_lib/const.py:3630
 msgid "our views on whether the war in Iraq was justified"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3622
+#: src/lifesim_lib/const.py:3631
 msgid "our views on whether your race affects your intelligence"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3623
+#: src/lifesim_lib/const.py:3632
 msgid "our views on whether your race affects your sporting ability"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3624
+#: src/lifesim_lib/const.py:3633
 msgid "our views on whether the world is over populated and steps must be taken to reduce births"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3627
+#: src/lifesim_lib/const.py:3636
 msgid "whether or not euthanasia should be illegal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3628
+#: src/lifesim_lib/const.py:3637
 msgid "whether or not cloning is a valuable scientific pursuit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3629
+#: src/lifesim_lib/const.py:3638
 msgid "whether obesity is a disease and not a lifestyle choice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3630
+#: src/lifesim_lib/const.py:3639
 msgid "whether or not video games contribute to youth violence"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3631
+#: src/lifesim_lib/const.py:3640
 msgid "whether the drinking age should be lowered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3632
+#: src/lifesim_lib/const.py:3641
 msgid "whether the drinking age should be raised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3633
+#: src/lifesim_lib/const.py:3642
 msgid "whether the smoking age should be lowered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3634
+#: src/lifesim_lib/const.py:3643
 msgid "whether the smoking age should be raised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3635
+#: src/lifesim_lib/const.py:3644
 msgid "whether the age of consent should be lowered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3636
+#: src/lifesim_lib/const.py:3645
 msgid "whether the age of consent should be raised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3637
+#: src/lifesim_lib/const.py:3646
 msgid "whether the voting age should be lowered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3638
+#: src/lifesim_lib/const.py:3647
 msgid "whether the voting age should be raised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3639
+#: src/lifesim_lib/const.py:3648
 msgid "whether the driving age should be lowered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3640
+#: src/lifesim_lib/const.py:3649
 msgid "whether the driving age should be raised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3641
+#: src/lifesim_lib/const.py:3650
 msgid "whether the gambling age should be lowered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3642
+#: src/lifesim_lib/const.py:3651
 msgid "whether the gambling age should be raised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3643
+#: src/lifesim_lib/const.py:3652
 msgid "whether the military service age should be lowered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3644
+#: src/lifesim_lib/const.py:3653
 msgid "whether the military service age should be raised"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3645
+#: src/lifesim_lib/const.py:3654
 msgid "whether drugs should be accepted in sports"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3646
+#: src/lifesim_lib/const.py:3655
 msgid "whether self driving cars are going to make our lives easier"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3647
+#: src/lifesim_lib/const.py:3656
 msgid "whether climate change exists"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3648
+#: src/lifesim_lib/const.py:3657
 msgid "whether carbohydrates are more damaging than fats"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3649
+#: src/lifesim_lib/const.py:3658
 msgid "whether terrorism can be justifed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3650
+#: src/lifesim_lib/const.py:3659
 msgid "whether or not street prostitution should be illegal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3651
+#: src/lifesim_lib/const.py:3660
 msgid "whether or not prostitution in a brothel should be illegal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3652
+#: src/lifesim_lib/const.py:3661
 msgid "whether or not prostituting yourself in your own home should be illegal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3653
+#: src/lifesim_lib/const.py:3662
 msgid "whether prisoners should be allowed to vote"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3654
+#: src/lifesim_lib/const.py:3663
 msgid "whether prenuptual agreements make families stronger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3655
+#: src/lifesim_lib/const.py:3664
 msgid "whether corporal punishment should be allowed in schools"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3661
+#: src/lifesim_lib/const.py:3670
 msgid "if it is better to scrunch or fold"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3662
+#: src/lifesim_lib/const.py:3671
 msgid "if it is better to squat or sit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3663
+#: src/lifesim_lib/const.py:3672
 msgid "if it is better to shower or bath"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3664
+#: src/lifesim_lib/const.py:3673
 msgid "if it is better to wipe from the front or back"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3666
+#: src/lifesim_lib/const.py:3675
 msgid "your imaginary friend"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3667
+#: src/lifesim_lib/const.py:3676
 msgid "your most prized posession"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3674
+#: src/lifesim_lib/const.py:3683
 msgid "not spending enough time with your family"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3675
+#: src/lifesim_lib/const.py:3684
 msgid "whether you would rather have overly large hands or small feet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3677
+#: src/lifesim_lib/const.py:3686
 msgid "cloning"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3678
+#: src/lifesim_lib/const.py:3687
 msgid "cryptocurrencies"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3679
+#: src/lifesim_lib/const.py:3688
 msgid "good vs evil"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3680
+#: src/lifesim_lib/const.py:3689
 msgid "how to deal with poor grammar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3681
+#: src/lifesim_lib/const.py:3690
 msgid "investment options"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3682
+#: src/lifesim_lib/const.py:3691
 msgid "whether or not a hot dog qualifies as a sandwich"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3685
+#: src/lifesim_lib/const.py:3694
 msgid "the importance of not sucking your thumb"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3688
+#: src/lifesim_lib/const.py:3697
 msgid "not drawing on the kitchen table"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3691
+#: src/lifesim_lib/const.py:3700
 msgid "the importance of cleaning up after yourself"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3693
+#: src/lifesim_lib/const.py:3702
 msgid "the importance of saving for retirement"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3697
+#: src/lifesim_lib/const.py:3706
 msgid "the best gift you ever received"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3698
+#: src/lifesim_lib/const.py:3707
 msgid "your most bizarre pet peeves"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3699
+#: src/lifesim_lib/const.py:3708
 msgid "why you love your closest friends"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3700
+#: src/lifesim_lib/const.py:3709
 msgid "your favourite books to read at the beach"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3701
+#: src/lifesim_lib/const.py:3710
 msgid "your favourite foods to eat on a cold night"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3702
+#: src/lifesim_lib/const.py:3711
 msgid "your biggest turn offs in other people"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3703
+#: src/lifesim_lib/const.py:3712
 msgid "remembering the times when you've felt closest together"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3704
+#: src/lifesim_lib/const.py:3713
 msgid "what you would do if you knew you couldn't fail"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3705
+#: src/lifesim_lib/const.py:3714
 msgid "your favourite summertime memory"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3706
+#: src/lifesim_lib/const.py:3715
 msgid "something you've always wanted to try"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3707
+#: src/lifesim_lib/const.py:3716
 msgid "things you've always wanted to try"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3708
+#: src/lifesim_lib/const.py:3717
 msgid "a moment in history you would have liked to have been a part of"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3709
+#: src/lifesim_lib/const.py:3718
 msgid "how to manage money better"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3710
+#: src/lifesim_lib/const.py:3719
 msgid "where you would go if you could time travel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3711
+#: src/lifesim_lib/const.py:3720
 msgid "what superpower you would have if you could have one"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3712
+#: src/lifesim_lib/const.py:3721
 msgid "what you're feeling thankful for today"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3713
+#: src/lifesim_lib/const.py:3722
 msgid "how much they mean to you"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3714
+#: src/lifesim_lib/const.py:3723
 msgid "something that you know you don't need but you're really grateful you have"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3715
+#: src/lifesim_lib/const.py:3724
 msgid "your fears of not accomplishing your New Year resolutions"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3716
+#: src/lifesim_lib/const.py:3725
 msgid "how silly New Year's resolutions are"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3717
+#: src/lifesim_lib/const.py:3726
 msgid "the best part of your day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3720
+#: src/lifesim_lib/const.py:3729
 msgid "what happens when we die"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3727
+#: src/lifesim_lib/const.py:3736
 msgid "shopping at a flea market"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3728
+#: src/lifesim_lib/const.py:3737
 msgid "bowling"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3729
+#: src/lifesim_lib/const.py:3738
 msgid "to the beach"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3730
+#: src/lifesim_lib/const.py:3739
 msgid "to play golf"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3731
+#: src/lifesim_lib/const.py:3740
 msgid "to do some gardening"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3732
+#: src/lifesim_lib/const.py:3741
 msgid "to a pilates class"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3733
+#: src/lifesim_lib/const.py:3742
 msgid "to play catch"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3734
+#: src/lifesim_lib/const.py:3743
 msgid "to make homemade mini pizzas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3735
+#: src/lifesim_lib/const.py:3744
 msgid "to perform in a flashmob at the courthouse"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3736
+#: src/lifesim_lib/const.py:3745
 msgid "to do a puzzle at the library"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3737
+#: src/lifesim_lib/const.py:3746
 msgid "to relax while floating in a natural hot spring"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3738
+#: src/lifesim_lib/const.py:3747
 msgid "crocheting"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3739
+#: src/lifesim_lib/const.py:3748
 msgid "to bring donuts to the police station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3740
+#: src/lifesim_lib/const.py:3749
 msgid "to blow bubbles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3741
+#: src/lifesim_lib/const.py:3750
 msgid "bird-watching"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3742
+#: src/lifesim_lib/const.py:3751
 msgid "for a picnic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3743
+#: src/lifesim_lib/const.py:3752
 msgid "to a baseball game"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3744
+#: src/lifesim_lib/const.py:3753
 msgid "to an arcade"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3745
+#: src/lifesim_lib/const.py:3754
 msgid "to an art museum"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3746
+#: src/lifesim_lib/const.py:3755
 msgid "to a tennis match"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3747
+#: src/lifesim_lib/const.py:3756
 msgid "to the circus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3748
+#: src/lifesim_lib/const.py:3757
 msgid "to the movies"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3749
+#: src/lifesim_lib/const.py:3758
 msgid "to play tennis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3750
+#: src/lifesim_lib/const.py:3759
 msgid "to fly a kite"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3751
+#: src/lifesim_lib/const.py:3760
 msgid "bungee-jumping"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3752
+#: src/lifesim_lib/const.py:3761
 msgid "fishing"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3753
+#: src/lifesim_lib/const.py:3762
 msgid "shopping"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3754
+#: src/lifesim_lib/const.py:3763
 msgid "to a hockey game"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3760
+#: src/lifesim_lib/const.py:3769
 msgid "listened to hip-hop music with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3761
+#: src/lifesim_lib/const.py:3770
 msgid "listened to classical music with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3762
+#: src/lifesim_lib/const.py:3771
 msgid "played with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3766 src/lifesim_lib/const.py:3774
+#: src/lifesim_lib/const.py:3775 src/lifesim_lib/const.py:3783
 msgid "curled up and watched a movie with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3767
+#: src/lifesim_lib/const.py:3776
 msgid "let a motorised weasel ball loose for your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3768 src/lifesim_lib/const.py:3780
+#: src/lifesim_lib/const.py:3777 src/lifesim_lib/const.py:3789
 msgid "made an obstacle course for your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3769
+#: src/lifesim_lib/const.py:3778
 msgid "used a cucumber to take prank videos of your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3770
+#: src/lifesim_lib/const.py:3779
 msgid "used a laser pointer to play with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3771
+#: src/lifesim_lib/const.py:3780
 msgid "rolled a ball or yarn across the floor for your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3775
+#: src/lifesim_lib/const.py:3784
 msgid "did the 'What The Fluff' challenge with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3776
+#: src/lifesim_lib/const.py:3785
 msgid "gave belly rubs, pats and scratches to your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3777
+#: src/lifesim_lib/const.py:3786
 msgid "jingled some keys loudly, and went out to walk your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3778
+#: src/lifesim_lib/const.py:3787
 msgid "made a breadcrumb trail of dog biscuits for your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3779
+#: src/lifesim_lib/const.py:3788
 msgid "made a breadcrumb trail of dog biscuits leading to a bone for your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3781
+#: src/lifesim_lib/const.py:3790
 msgid "loudly announced walk time, and went walking with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3782
+#: src/lifesim_lib/const.py:3791
 msgid "said 'Walkies!', and went walking with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3783
+#: src/lifesim_lib/const.py:3792
 msgid "went swimming at the beach with your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3784
+#: src/lifesim_lib/const.py:3793
 msgid "went to the park and threw a ball for your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3785
+#: src/lifesim_lib/const.py:3794
 msgid "went to the river and threw sticks in it for your"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3792
+#: src/lifesim_lib/const.py:3801
 msgid "The Dominican Republic's forces have been withdrawn from Haiti, indicating an end to the war. In total, there were more than 10,000 casualties as a result of the conflict"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3799
+#: src/lifesim_lib/const.py:3808
 msgid "You weren't doing anything fun, but then your friend came over wanting to go out and play. You both had a blast!"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3824
+#: src/lifesim_lib/const.py:3833
 msgid "cat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3825
+#: src/lifesim_lib/const.py:3834
 msgid "dog"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3826
+#: src/lifesim_lib/const.py:3835
 msgid "fish"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3830
+#: src/lifesim_lib/const.py:3839
 msgid "Abyssinian Cat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3831
+#: src/lifesim_lib/const.py:3840
 msgid "America Shorthair Cat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3832
+#: src/lifesim_lib/const.py:3841
 msgid "House Cat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3833
+#: src/lifesim_lib/const.py:3842
 msgid "Tabby Cat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3836
+#: src/lifesim_lib/const.py:3845
 msgid "Cairn Terrier"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3837
+#: src/lifesim_lib/const.py:3846
 msgid "German Shepherd"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3838
+#: src/lifesim_lib/const.py:3847
 msgid "Mutt"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3841
+#: src/lifesim_lib/const.py:3850
 msgid "Betta Fish"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3845 src/lifesim_lib/const.py:4060
+#: src/lifesim_lib/const.py:3854 src/lifesim_lib/const.py:4069
 msgid "Oliver"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3846 src/lifesim_lib/const.py:4055
+#: src/lifesim_lib/const.py:3855 src/lifesim_lib/const.py:4064
 msgid "Leo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3847 src/lifesim_lib/const.py:4051
+#: src/lifesim_lib/const.py:3856 src/lifesim_lib/const.py:4060
 msgid "Milo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3848 src/lifesim_lib/const.py:3984
-#: src/lifesim_lib/const.py:4050 src/lifesim_lib/const.py:4194
+#: src/lifesim_lib/const.py:3857 src/lifesim_lib/const.py:3993
+#: src/lifesim_lib/const.py:4059 src/lifesim_lib/const.py:4203
 msgid "Charlie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3849 src/lifesim_lib/const.py:4049
+#: src/lifesim_lib/const.py:3858 src/lifesim_lib/const.py:4058
 msgid "Max"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3850 src/lifesim_lib/const.py:4081
+#: src/lifesim_lib/const.py:3859 src/lifesim_lib/const.py:4090
 msgid "Simba"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3851 src/lifesim_lib/const.py:4061
+#: src/lifesim_lib/const.py:3860 src/lifesim_lib/const.py:4070
 msgid "Jack"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3852 src/lifesim_lib/const.py:4070
+#: src/lifesim_lib/const.py:3861 src/lifesim_lib/const.py:4079
 msgid "Loki"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3853 src/lifesim_lib/const.py:4063
+#: src/lifesim_lib/const.py:3862 src/lifesim_lib/const.py:4072
 msgid "Ollie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3854 src/lifesim_lib/const.py:4092
+#: src/lifesim_lib/const.py:3863 src/lifesim_lib/const.py:4101
 msgid "Jasper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3855 src/lifesim_lib/const.py:4052
+#: src/lifesim_lib/const.py:3864 src/lifesim_lib/const.py:4061
 msgid "Buddy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3856 src/lifesim_lib/const.py:4019
+#: src/lifesim_lib/const.py:3865 src/lifesim_lib/const.py:4028
 msgid "Smokey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3857 src/lifesim_lib/const.py:4093
+#: src/lifesim_lib/const.py:3866 src/lifesim_lib/const.py:4102
 msgid "Oscar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3858 src/lifesim_lib/const.py:4064
+#: src/lifesim_lib/const.py:3867 src/lifesim_lib/const.py:4073
 msgid "Toby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3859 src/lifesim_lib/const.py:4037
+#: src/lifesim_lib/const.py:3868 src/lifesim_lib/const.py:4046
 msgid "Tiger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3860 src/lifesim_lib/const.py:4067
+#: src/lifesim_lib/const.py:3869 src/lifesim_lib/const.py:4076
 msgid "Finn"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3861
+#: src/lifesim_lib/const.py:3870
 msgid "Simon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3862 src/lifesim_lib/const.py:4028
+#: src/lifesim_lib/const.py:3871 src/lifesim_lib/const.py:4037
 msgid "Binx"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3863 src/lifesim_lib/const.py:4068
+#: src/lifesim_lib/const.py:3872 src/lifesim_lib/const.py:4077
 msgid "Louie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3864 src/lifesim_lib/const.py:4079
+#: src/lifesim_lib/const.py:3873 src/lifesim_lib/const.py:4088
 msgid "Henry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3865 src/lifesim_lib/const.py:3982
-#: src/lifesim_lib/const.py:4096
+#: src/lifesim_lib/const.py:3874 src/lifesim_lib/const.py:3991
+#: src/lifesim_lib/const.py:4105
 msgid "Oreo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3866 src/lifesim_lib/const.py:4062
+#: src/lifesim_lib/const.py:3875 src/lifesim_lib/const.py:4071
 msgid "Winston"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3867 src/lifesim_lib/const.py:4001
+#: src/lifesim_lib/const.py:3876 src/lifesim_lib/const.py:4010
 msgid "Salem"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3868 src/lifesim_lib/const.py:4072
+#: src/lifesim_lib/const.py:3877 src/lifesim_lib/const.py:4081
 msgid "Gus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3869
+#: src/lifesim_lib/const.py:3878
 msgid "Felix"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3870
+#: src/lifesim_lib/const.py:3879
 msgid "Tigger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3872 src/lifesim_lib/const.py:3952
+#: src/lifesim_lib/const.py:3881 src/lifesim_lib/const.py:3961
 msgid "Kitty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3873 src/lifesim_lib/const.py:4108
+#: src/lifesim_lib/const.py:3882 src/lifesim_lib/const.py:4117
 msgid "Sam"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3874 src/lifesim_lib/const.py:4057
+#: src/lifesim_lib/const.py:3883 src/lifesim_lib/const.py:4066
 msgid "Teddy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3875 src/lifesim_lib/const.py:4075
+#: src/lifesim_lib/const.py:3884 src/lifesim_lib/const.py:4084
 msgid "Apollo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3876 src/lifesim_lib/const.py:4024
+#: src/lifesim_lib/const.py:3885 src/lifesim_lib/const.py:4033
 msgid "Blu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3877 src/lifesim_lib/const.py:4111
+#: src/lifesim_lib/const.py:3886 src/lifesim_lib/const.py:4120
 msgid "Gizmo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3878 src/lifesim_lib/const.py:4077
+#: src/lifesim_lib/const.py:3887 src/lifesim_lib/const.py:4086
 msgid "Archie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3879 src/lifesim_lib/const.py:4065
+#: src/lifesim_lib/const.py:3888 src/lifesim_lib/const.py:4074
 msgid "Jax"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3880 src/lifesim_lib/const.py:4054
+#: src/lifesim_lib/const.py:3889 src/lifesim_lib/const.py:4063
 msgid "Bear"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3881 src/lifesim_lib/const.py:4031
+#: src/lifesim_lib/const.py:3890 src/lifesim_lib/const.py:4040
 msgid "Boots"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3882 src/lifesim_lib/const.py:4010
-#: src/lifesim_lib/const.py:4116 src/lifesim_lib/const.py:4233
+#: src/lifesim_lib/const.py:3891 src/lifesim_lib/const.py:4019
+#: src/lifesim_lib/const.py:4125 src/lifesim_lib/const.py:4242
 msgid "Frankie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3883 src/lifesim_lib/const.py:4144
+#: src/lifesim_lib/const.py:3892 src/lifesim_lib/const.py:4153
 msgid "Chester"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3884 src/lifesim_lib/const.py:4094
+#: src/lifesim_lib/const.py:3893 src/lifesim_lib/const.py:4103
 msgid "Bandit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3885 src/lifesim_lib/const.py:4059
+#: src/lifesim_lib/const.py:3894 src/lifesim_lib/const.py:4068
 msgid "Beau"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3886 src/lifesim_lib/const.py:3978
+#: src/lifesim_lib/const.py:3895 src/lifesim_lib/const.py:3987
 msgid "Pumpkin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3887 src/lifesim_lib/const.py:4141
+#: src/lifesim_lib/const.py:3896 src/lifesim_lib/const.py:4150
 msgid "Cosmo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3888 src/lifesim_lib/const.py:4033
-#: src/lifesim_lib/const.py:4086
+#: src/lifesim_lib/const.py:3897 src/lifesim_lib/const.py:4042
+#: src/lifesim_lib/const.py:4095
 msgid "Lucky"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3889 src/lifesim_lib/const.py:4080
+#: src/lifesim_lib/const.py:3898 src/lifesim_lib/const.py:4089
 msgid "Thor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3890 src/lifesim_lib/const.py:4136
+#: src/lifesim_lib/const.py:3899 src/lifesim_lib/const.py:4145
 msgid "Frank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3891 src/lifesim_lib/const.py:4005
+#: src/lifesim_lib/const.py:3900 src/lifesim_lib/const.py:4014
 msgid "Midnight"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3892 src/lifesim_lib/const.py:4090
+#: src/lifesim_lib/const.py:3901 src/lifesim_lib/const.py:4099
 msgid "Benny"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3893
+#: src/lifesim_lib/const.py:3902
 msgid "Tom"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3894 src/lifesim_lib/const.py:3992
+#: src/lifesim_lib/const.py:3903 src/lifesim_lib/const.py:4001
 msgid "Boo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3895
+#: src/lifesim_lib/const.py:3904
 msgid "Ash"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3896 src/lifesim_lib/const.py:4122
+#: src/lifesim_lib/const.py:3905 src/lifesim_lib/const.py:4131
 msgid "Romeo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3897 src/lifesim_lib/const.py:4131
+#: src/lifesim_lib/const.py:3906 src/lifesim_lib/const.py:4140
 msgid "Goose"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3898 src/lifesim_lib/const.py:4129
+#: src/lifesim_lib/const.py:3907 src/lifesim_lib/const.py:4138
 msgid "Joey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3899 src/lifesim_lib/const.py:3997
+#: src/lifesim_lib/const.py:3908 src/lifesim_lib/const.py:4006
 msgid "Mochi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3900 src/lifesim_lib/const.py:4120
+#: src/lifesim_lib/const.py:3909 src/lifesim_lib/const.py:4129
 msgid "Ozzy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3901
+#: src/lifesim_lib/const.py:3910
 msgid "Merlin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3902 src/lifesim_lib/const.py:4103
+#: src/lifesim_lib/const.py:3911 src/lifesim_lib/const.py:4112
 msgid "Prince"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3903 src/lifesim_lib/const.py:3963
-#: src/lifesim_lib/const.py:4178
+#: src/lifesim_lib/const.py:3912 src/lifesim_lib/const.py:3972
+#: src/lifesim_lib/const.py:4187
 msgid "Pepper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3904 src/lifesim_lib/const.py:4115
+#: src/lifesim_lib/const.py:3913 src/lifesim_lib/const.py:4124
 msgid "Bruce"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3905 src/lifesim_lib/const.py:4088
+#: src/lifesim_lib/const.py:3914 src/lifesim_lib/const.py:4097
 msgid "Otis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3906
+#: src/lifesim_lib/const.py:3915
 msgid "Harry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3907
+#: src/lifesim_lib/const.py:3916
 msgid "Percy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3908 src/lifesim_lib/const.py:4006
-#: src/lifesim_lib/const.py:4126 src/lifesim_lib/const.py:4243
+#: src/lifesim_lib/const.py:3917 src/lifesim_lib/const.py:4015
+#: src/lifesim_lib/const.py:4135 src/lifesim_lib/const.py:4252
 msgid "Peanut"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3909 src/lifesim_lib/const.py:4002
+#: src/lifesim_lib/const.py:3918 src/lifesim_lib/const.py:4011
 msgid "Bean"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3910 src/lifesim_lib/const.py:4058
+#: src/lifesim_lib/const.py:3919 src/lifesim_lib/const.py:4067
 msgid "Tucker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3911 src/lifesim_lib/const.py:4069
+#: src/lifesim_lib/const.py:3920 src/lifesim_lib/const.py:4078
 msgid "Murphy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3912 src/lifesim_lib/const.py:4071
+#: src/lifesim_lib/const.py:3921 src/lifesim_lib/const.py:4080
 msgid "Moose"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3913 src/lifesim_lib/const.py:4124
+#: src/lifesim_lib/const.py:3922 src/lifesim_lib/const.py:4133
 msgid "Mac"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3914
+#: src/lifesim_lib/const.py:3923
 msgid "Kevin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3915
+#: src/lifesim_lib/const.py:3924
 msgid "Casper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3916 src/lifesim_lib/const.py:4087
+#: src/lifesim_lib/const.py:3925 src/lifesim_lib/const.py:4096
 msgid "Buster"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3917 src/lifesim_lib/const.py:4259
+#: src/lifesim_lib/const.py:3926 src/lifesim_lib/const.py:4268
 msgid "Bob"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3918
+#: src/lifesim_lib/const.py:3927
 msgid "Thomas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3919 src/lifesim_lib/const.py:4089
+#: src/lifesim_lib/const.py:3928 src/lifesim_lib/const.py:4098
 msgid "Jackson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3920
+#: src/lifesim_lib/const.py:3929
 msgid "Sylvester"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3921 src/lifesim_lib/const.py:4085
+#: src/lifesim_lib/const.py:3930 src/lifesim_lib/const.py:4094
 msgid "Jake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3922
+#: src/lifesim_lib/const.py:3931
 msgid "Fred"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3923
+#: src/lifesim_lib/const.py:3932
 msgid "Mango"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3924
+#: src/lifesim_lib/const.py:3933
 msgid "Sunny"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3925 src/lifesim_lib/const.py:4076
+#: src/lifesim_lib/const.py:3934 src/lifesim_lib/const.py:4085
 msgid "Hank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3926 src/lifesim_lib/const.py:4125
+#: src/lifesim_lib/const.py:3935 src/lifesim_lib/const.py:4134
 msgid "Bubba"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3927
+#: src/lifesim_lib/const.py:3936
 msgid "Calvin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3928 src/lifesim_lib/const.py:4106
-#: src/lifesim_lib/const.py:4208
+#: src/lifesim_lib/const.py:3937 src/lifesim_lib/const.py:4115
+#: src/lifesim_lib/const.py:4217
 msgid "Marley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3929 src/lifesim_lib/const.py:3969
-#: src/lifesim_lib/const.py:4100 src/lifesim_lib/const.py:4166
+#: src/lifesim_lib/const.py:3938 src/lifesim_lib/const.py:3978
+#: src/lifesim_lib/const.py:4109 src/lifesim_lib/const.py:4175
 msgid "Coco"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3930 src/lifesim_lib/const.py:4148
+#: src/lifesim_lib/const.py:3939 src/lifesim_lib/const.py:4157
 msgid "Louis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3931
+#: src/lifesim_lib/const.py:3940
 msgid "Tony"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3932
+#: src/lifesim_lib/const.py:3941
 msgid "Bagheera"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3933 src/lifesim_lib/const.py:4056
+#: src/lifesim_lib/const.py:3942 src/lifesim_lib/const.py:4065
 msgid "Duke"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3934
+#: src/lifesim_lib/const.py:3943
 msgid "Clyde"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3935 src/lifesim_lib/const.py:4119
+#: src/lifesim_lib/const.py:3944 src/lifesim_lib/const.py:4128
 msgid "Hunter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3936 src/lifesim_lib/const.py:3988
+#: src/lifesim_lib/const.py:3945 src/lifesim_lib/const.py:3997
 msgid "Mittens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3937 src/lifesim_lib/const.py:4113
+#: src/lifesim_lib/const.py:3946 src/lifesim_lib/const.py:4122
 msgid "Luke"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3938
+#: src/lifesim_lib/const.py:3947
 msgid "Nugget"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3939 src/lifesim_lib/const.py:4074
+#: src/lifesim_lib/const.py:3948 src/lifesim_lib/const.py:4083
 msgid "Ace"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3940 src/lifesim_lib/const.py:4020
-#: src/lifesim_lib/const.py:4083 src/lifesim_lib/const.py:4210
+#: src/lifesim_lib/const.py:3949 src/lifesim_lib/const.py:4029
+#: src/lifesim_lib/const.py:4092 src/lifesim_lib/const.py:4219
 msgid "Scout"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3941
+#: src/lifesim_lib/const.py:3950
 msgid "Tito"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3942
+#: src/lifesim_lib/const.py:3951
 msgid "Monty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3943 src/lifesim_lib/const.py:4145
+#: src/lifesim_lib/const.py:3952 src/lifesim_lib/const.py:4154
 msgid "Wally"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3944
+#: src/lifesim_lib/const.py:3953
 msgid "Alex"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3947 src/lifesim_lib/const.py:4152
+#: src/lifesim_lib/const.py:3956 src/lifesim_lib/const.py:4161
 msgid "Luna"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3948 src/lifesim_lib/const.py:4151
+#: src/lifesim_lib/const.py:3957 src/lifesim_lib/const.py:4160
 msgid "Bella"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3949 src/lifesim_lib/const.py:4165
+#: src/lifesim_lib/const.py:3958 src/lifesim_lib/const.py:4174
 msgid "Lily"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3950 src/lifesim_lib/const.py:4153
+#: src/lifesim_lib/const.py:3959 src/lifesim_lib/const.py:4162
 msgid "Lucy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3951 src/lifesim_lib/const.py:4163
+#: src/lifesim_lib/const.py:3960 src/lifesim_lib/const.py:4172
 msgid "Nala"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3953 src/lifesim_lib/const.py:4161
+#: src/lifesim_lib/const.py:3962 src/lifesim_lib/const.py:4170
 msgid "Chloe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3954 src/lifesim_lib/const.py:4159
+#: src/lifesim_lib/const.py:3963 src/lifesim_lib/const.py:4168
 msgid "Stella"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3955 src/lifesim_lib/const.py:4186
+#: src/lifesim_lib/const.py:3964 src/lifesim_lib/const.py:4195
 msgid "Zoe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3956 src/lifesim_lib/const.py:4155
+#: src/lifesim_lib/const.py:3965 src/lifesim_lib/const.py:4164
 msgid "Lola"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3957 src/lifesim_lib/const.py:4229
+#: src/lifesim_lib/const.py:3966 src/lifesim_lib/const.py:4238
 msgid "Cleo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3958 src/lifesim_lib/const.py:4154
+#: src/lifesim_lib/const.py:3967 src/lifesim_lib/const.py:4163
 msgid "Daisy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3959 src/lifesim_lib/const.py:4167
+#: src/lifesim_lib/const.py:3968 src/lifesim_lib/const.py:4176
 msgid "Sophie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3960 src/lifesim_lib/const.py:4176
+#: src/lifesim_lib/const.py:3969 src/lifesim_lib/const.py:4185
 msgid "Willow"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3961 src/lifesim_lib/const.py:4193
+#: src/lifesim_lib/const.py:3970 src/lifesim_lib/const.py:4202
 msgid "Olive"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3962 src/lifesim_lib/const.py:4162
+#: src/lifesim_lib/const.py:3971 src/lifesim_lib/const.py:4171
 msgid "Penny"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3964 src/lifesim_lib/const.py:4168
+#: src/lifesim_lib/const.py:3973 src/lifesim_lib/const.py:4177
 msgid "Rosie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3965 src/lifesim_lib/const.py:4157
+#: src/lifesim_lib/const.py:3974 src/lifesim_lib/const.py:4166
 msgid "Molly"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3966
+#: src/lifesim_lib/const.py:3975
 msgid "Kiki"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3967 src/lifesim_lib/const.py:4169
+#: src/lifesim_lib/const.py:3976 src/lifesim_lib/const.py:4178
 msgid "Ellie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3968 src/lifesim_lib/const.py:4204
+#: src/lifesim_lib/const.py:3977 src/lifesim_lib/const.py:4213
 msgid "Phoebe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3970 src/lifesim_lib/const.py:4177
+#: src/lifesim_lib/const.py:3979 src/lifesim_lib/const.py:4186
 msgid "Lulu"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3971 src/lifesim_lib/const.py:4203
+#: src/lifesim_lib/const.py:3980 src/lifesim_lib/const.py:4212
 msgid "Princess"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3972 src/lifesim_lib/const.py:4160
+#: src/lifesim_lib/const.py:3981 src/lifesim_lib/const.py:4169
 msgid "Maggie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3973 src/lifesim_lib/const.py:4171
+#: src/lifesim_lib/const.py:3982 src/lifesim_lib/const.py:4180
 msgid "Piper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3974 src/lifesim_lib/const.py:4175
+#: src/lifesim_lib/const.py:3983 src/lifesim_lib/const.py:4184
 msgid "Millie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3975 src/lifesim_lib/const.py:4179
+#: src/lifesim_lib/const.py:3984 src/lifesim_lib/const.py:4188
 msgid "Ginger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3976 src/lifesim_lib/const.py:4183
+#: src/lifesim_lib/const.py:3985 src/lifesim_lib/const.py:4192
 msgid "Nova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3977 src/lifesim_lib/const.py:4191
+#: src/lifesim_lib/const.py:3986 src/lifesim_lib/const.py:4200
 msgid "Hazel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3979 src/lifesim_lib/const.py:4170
+#: src/lifesim_lib/const.py:3988 src/lifesim_lib/const.py:4179
 msgid "Ruby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3980 src/lifesim_lib/const.py:4230
+#: src/lifesim_lib/const.py:3989 src/lifesim_lib/const.py:4239
 msgid "Penelope"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3981 src/lifesim_lib/const.py:4238
+#: src/lifesim_lib/const.py:3990 src/lifesim_lib/const.py:4247
 msgid "Fiona"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3983
+#: src/lifesim_lib/const.py:3992
 msgid "Baby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3985 src/lifesim_lib/const.py:4182
+#: src/lifesim_lib/const.py:3994 src/lifesim_lib/const.py:4191
 msgid "Winnie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3986 src/lifesim_lib/const.py:4213
+#: src/lifesim_lib/const.py:3995 src/lifesim_lib/const.py:4222
 msgid "Minnie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3987 src/lifesim_lib/const.py:4181
+#: src/lifesim_lib/const.py:3996 src/lifesim_lib/const.py:4190
 msgid "Abby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3989 src/lifesim_lib/const.py:4217
+#: src/lifesim_lib/const.py:3998 src/lifesim_lib/const.py:4226
 msgid "Poppy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3990 src/lifesim_lib/const.py:4207
+#: src/lifesim_lib/const.py:3999 src/lifesim_lib/const.py:4216
 msgid "Cookie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3991 src/lifesim_lib/const.py:4224
+#: src/lifesim_lib/const.py:4000 src/lifesim_lib/const.py:4233
 msgid "Ivy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3993 src/lifesim_lib/const.py:4173
+#: src/lifesim_lib/const.py:4002 src/lifesim_lib/const.py:4182
 msgid "Roxy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3994 src/lifesim_lib/const.py:4202
+#: src/lifesim_lib/const.py:4003 src/lifesim_lib/const.py:4211
 msgid "Belle"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3995 src/lifesim_lib/const.py:4206
+#: src/lifesim_lib/const.py:4004 src/lifesim_lib/const.py:4215
 msgid "Ella"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3996
+#: src/lifesim_lib/const.py:4005
 msgid "Zelda"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3998
+#: src/lifesim_lib/const.py:4007
 msgid "Alice"
 msgstr ""
 
-#: src/lifesim_lib/const.py:3999 src/lifesim_lib/const.py:4221
+#: src/lifesim_lib/const.py:4008 src/lifesim_lib/const.py:4230
 msgid "Angel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4000 src/lifesim_lib/const.py:4205
+#: src/lifesim_lib/const.py:4009 src/lifesim_lib/const.py:4214
 msgid "Emma"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4003
+#: src/lifesim_lib/const.py:4012
 msgid "Freya"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4004 src/lifesim_lib/const.py:4082
-#: src/lifesim_lib/const.py:4158
+#: src/lifesim_lib/const.py:4013 src/lifesim_lib/const.py:4091
+#: src/lifesim_lib/const.py:4167
 msgid "Bailey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4007 src/lifesim_lib/const.py:4216
+#: src/lifesim_lib/const.py:4016 src/lifesim_lib/const.py:4225
 msgid "Leia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4008
+#: src/lifesim_lib/const.py:4017
 msgid "Peaches"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4009 src/lifesim_lib/const.py:4226
+#: src/lifesim_lib/const.py:4018 src/lifesim_lib/const.py:4235
 msgid "Gigi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4011 src/lifesim_lib/const.py:4197
+#: src/lifesim_lib/const.py:4020 src/lifesim_lib/const.py:4206
 msgid "Honey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4012
+#: src/lifesim_lib/const.py:4021
 msgid "Violet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4013
+#: src/lifesim_lib/const.py:4022
 msgid "Charlotte"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4014
+#: src/lifesim_lib/const.py:4023
 msgid "Olivia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4015
+#: src/lifesim_lib/const.py:4024
 msgid "Sage"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4016
+#: src/lifesim_lib/const.py:4025
 msgid "Stormy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4017
+#: src/lifesim_lib/const.py:4026
 msgid "Kiwi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4018 src/lifesim_lib/const.py:4231
+#: src/lifesim_lib/const.py:4027 src/lifesim_lib/const.py:4240
 msgid "Bonnie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4021
+#: src/lifesim_lib/const.py:4030
 msgid "Arya"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4022
+#: src/lifesim_lib/const.py:4031
 msgid "Sushi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4023 src/lifesim_lib/const.py:4234
+#: src/lifesim_lib/const.py:4032 src/lifesim_lib/const.py:4243
 msgid "Sugar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4025 src/lifesim_lib/const.py:4218
+#: src/lifesim_lib/const.py:4034 src/lifesim_lib/const.py:4227
 msgid "Josie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4026
+#: src/lifesim_lib/const.py:4035
 msgid "Gypsy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4027 src/lifesim_lib/const.py:4225
+#: src/lifesim_lib/const.py:4036 src/lifesim_lib/const.py:4234
 msgid "Mocha"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4029 src/lifesim_lib/const.py:4250
+#: src/lifesim_lib/const.py:4038 src/lifesim_lib/const.py:4259
 msgid "Trixie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4030
+#: src/lifesim_lib/const.py:4039
 msgid "Snickers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4032
+#: src/lifesim_lib/const.py:4041
 msgid "Iris"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4034 src/lifesim_lib/const.py:4189
+#: src/lifesim_lib/const.py:4043 src/lifesim_lib/const.py:4198
 msgid "Lady"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4035
+#: src/lifesim_lib/const.py:4044
 msgid "Elsa"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4036
+#: src/lifesim_lib/const.py:4045
 msgid "Pixie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4038 src/lifesim_lib/const.py:4223
+#: src/lifesim_lib/const.py:4047 src/lifesim_lib/const.py:4232
 msgid "Ava"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4039 src/lifesim_lib/const.py:4222
+#: src/lifesim_lib/const.py:4048 src/lifesim_lib/const.py:4231
 msgid "Holly"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4040
+#: src/lifesim_lib/const.py:4049
 msgid "Tilly"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4041 src/lifesim_lib/const.py:4244
+#: src/lifesim_lib/const.py:4050 src/lifesim_lib/const.py:4253
 msgid "Grace"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4042
+#: src/lifesim_lib/const.py:4051
 msgid "Opal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4043
+#: src/lifesim_lib/const.py:4052
 msgid "Peach"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4044
+#: src/lifesim_lib/const.py:4053
 msgid "Muffin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4045
+#: src/lifesim_lib/const.py:4054
 msgid "Maple"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4046
+#: src/lifesim_lib/const.py:4055
 msgid "Sally"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4066
+#: src/lifesim_lib/const.py:4075
 msgid "Blue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4073
+#: src/lifesim_lib/const.py:4082
 msgid "Bruno"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4078
+#: src/lifesim_lib/const.py:4087
 msgid "Kobe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4091
+#: src/lifesim_lib/const.py:4100
 msgid "Chewy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4095
+#: src/lifesim_lib/const.py:4104
 msgid "Rex"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4097 src/lifesim_lib/const.py:4185
+#: src/lifesim_lib/const.py:4106 src/lifesim_lib/const.py:4194
 msgid "Riley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4098
+#: src/lifesim_lib/const.py:4107
 msgid "Baxter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4099
+#: src/lifesim_lib/const.py:4108
 msgid "Cody"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4101
+#: src/lifesim_lib/const.py:4110
 msgid "Rocco"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4102
+#: src/lifesim_lib/const.py:4111
 msgid "Tank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4104
+#: src/lifesim_lib/const.py:4113
 msgid "Ranger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4105
+#: src/lifesim_lib/const.py:4114
 msgid "King"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4107
+#: src/lifesim_lib/const.py:4116
 msgid "Roscoe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4110
+#: src/lifesim_lib/const.py:4119
 msgid "Copper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4112
+#: src/lifesim_lib/const.py:4121
 msgid "Chase"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4114
+#: src/lifesim_lib/const.py:4123
 msgid "Boomer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4117
+#: src/lifesim_lib/const.py:4126
 msgid "Chance"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4118
+#: src/lifesim_lib/const.py:4127
 msgid "Rusty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4121
+#: src/lifesim_lib/const.py:4130
 msgid "Tyson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4123
+#: src/lifesim_lib/const.py:4132
 msgid "Rudy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4127
+#: src/lifesim_lib/const.py:4136
 msgid "Kai"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4128
+#: src/lifesim_lib/const.py:4137
 msgid "Chico"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4130
+#: src/lifesim_lib/const.py:4139
 msgid "Atlas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4132
+#: src/lifesim_lib/const.py:4141
 msgid "Samson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4133
+#: src/lifesim_lib/const.py:4142
 msgid "Chief"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4134
+#: src/lifesim_lib/const.py:4143
 msgid "Levi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4135
+#: src/lifesim_lib/const.py:4144
 msgid "Titan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4137
+#: src/lifesim_lib/const.py:4146
 msgid "Axel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4138
+#: src/lifesim_lib/const.py:4147
 msgid "Brutus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4140
+#: src/lifesim_lib/const.py:4149
 msgid "Brady"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4142
+#: src/lifesim_lib/const.py:4151
 msgid "Scooby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4143
+#: src/lifesim_lib/const.py:4152
 msgid "Chip"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4146
+#: src/lifesim_lib/const.py:4155
 msgid "Rufus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4147
+#: src/lifesim_lib/const.py:4156
 msgid "Dash"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4156
+#: src/lifesim_lib/const.py:4165
 msgid "Sadie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4164
+#: src/lifesim_lib/const.py:4173
 msgid "Zoey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4172
+#: src/lifesim_lib/const.py:4181
 msgid "Mia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4174
+#: src/lifesim_lib/const.py:4183
 msgid "Gracie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4180
+#: src/lifesim_lib/const.py:4189
 msgid "Harley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4184
+#: src/lifesim_lib/const.py:4193
 msgid "Kona"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4187
+#: src/lifesim_lib/const.py:4196
 msgid "Lilly"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4188
+#: src/lifesim_lib/const.py:4197
 msgid "Dixie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4190
+#: src/lifesim_lib/const.py:4199
 msgid "Izzy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4192
+#: src/lifesim_lib/const.py:4201
 msgid "Layla"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4195
+#: src/lifesim_lib/const.py:4204
 msgid "Sasha"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4196
+#: src/lifesim_lib/const.py:4205
 msgid "Maya"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4198
+#: src/lifesim_lib/const.py:4207
 msgid "Athena"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4199
+#: src/lifesim_lib/const.py:4208
 msgid "Lexi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4200
+#: src/lifesim_lib/const.py:4209
 msgid "Cali"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4201
+#: src/lifesim_lib/const.py:4210
 msgid "Annie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4209
+#: src/lifesim_lib/const.py:4218
 msgid "Callie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4211
+#: src/lifesim_lib/const.py:4220
 msgid "Roxie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4212
+#: src/lifesim_lib/const.py:4221
 msgid "Remi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4214
+#: src/lifesim_lib/const.py:4223
 msgid "Maddie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4215
+#: src/lifesim_lib/const.py:4224
 msgid "Dakota"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4219
+#: src/lifesim_lib/const.py:4228
 msgid "Harper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4220
+#: src/lifesim_lib/const.py:4229
 msgid "Mila"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4227
+#: src/lifesim_lib/const.py:4236
 msgid "Paisley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4228
+#: src/lifesim_lib/const.py:4237
 msgid "Koda"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4232
+#: src/lifesim_lib/const.py:4241
 msgid "Missy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4235
+#: src/lifesim_lib/const.py:4244
 msgid "Aspen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4236
+#: src/lifesim_lib/const.py:4245
 msgid "Xena"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4237
+#: src/lifesim_lib/const.py:4246
 msgid "Shelby"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4239
+#: src/lifesim_lib/const.py:4248
 msgid "Dolly"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4241
+#: src/lifesim_lib/const.py:4250
 msgid "Shadow"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4242
+#: src/lifesim_lib/const.py:4251
 msgid "Delilah"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4245
+#: src/lifesim_lib/const.py:4254
 msgid "Rose"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4246
+#: src/lifesim_lib/const.py:4255
 msgid "Skye"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4247
+#: src/lifesim_lib/const.py:4256
 msgid "Pearl"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4248
+#: src/lifesim_lib/const.py:4257
 msgid "Jasmine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4249
+#: src/lifesim_lib/const.py:4258
 msgid "Juno"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4253
+#: src/lifesim_lib/const.py:4262
 msgid "Finneaus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4254
+#: src/lifesim_lib/const.py:4263
 msgid "Fishy McFish"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4255
+#: src/lifesim_lib/const.py:4264
 msgid "Swimster"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4256
+#: src/lifesim_lib/const.py:4265
 msgid "Chips"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4257
+#: src/lifesim_lib/const.py:4266
 msgid "Caspian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4258
+#: src/lifesim_lib/const.py:4267
 msgid "Ripley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4260
+#: src/lifesim_lib/const.py:4269
 msgid "Bubbles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4261
+#: src/lifesim_lib/const.py:4270
 msgid "Bigmouth"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4262
+#: src/lifesim_lib/const.py:4271
 msgid "Swimzell"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4263
+#: src/lifesim_lib/const.py:4272
 msgid "Swim Shady"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4264
+#: src/lifesim_lib/const.py:4273
 msgid "Bigmouth Billy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4265
+#: src/lifesim_lib/const.py:4274
 msgid "Squirtle"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4266
+#: src/lifesim_lib/const.py:4275
 msgid "Long John Silver"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4267
+#: src/lifesim_lib/const.py:4276
 msgid "Mr. Ray"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4268
+#: src/lifesim_lib/const.py:4277
 msgid "Captain Morgan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4269
+#: src/lifesim_lib/const.py:4278
 msgid "Betta White"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4270
+#: src/lifesim_lib/const.py:4279
 msgid "Small Fry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4271
+#: src/lifesim_lib/const.py:4280
 msgid "Tuna Piano"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4272
+#: src/lifesim_lib/const.py:4281
 msgid "Harvey"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4281
+#: src/lifesim_lib/const.py:4290
 msgid "Alex Pettyfer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4282
+#: src/lifesim_lib/const.py:4291
 msgid "Ashton Kutcher"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4283
+#: src/lifesim_lib/const.py:4292
 msgid "Adam Brody"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4284
+#: src/lifesim_lib/const.py:4293
 msgid "Andrew Garfield"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4285
+#: src/lifesim_lib/const.py:4294
 msgid "Alexander Skarsgård"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4286
+#: src/lifesim_lib/const.py:4295
 msgid "Austin Nichols"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4287
+#: src/lifesim_lib/const.py:4296
 msgid "Allan Hyde"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4288
+#: src/lifesim_lib/const.py:4297
 msgid "Adam Garcia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4289 src/lifesim_lib/const.py:4382
-#: src/lifesim_lib/const.py:4413 src/lifesim_lib/const.py:4419
-#: src/lifesim_lib/const.py:4431
+#: src/lifesim_lib/const.py:4298 src/lifesim_lib/const.py:4391
+#: src/lifesim_lib/const.py:4422 src/lifesim_lib/const.py:4428
+#: src/lifesim_lib/const.py:4440
 msgid "Arnold Schwarzenegger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4290
+#: src/lifesim_lib/const.py:4299
 msgid "Ben McKenzie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4291
+#: src/lifesim_lib/const.py:4300
 msgid "Bryan Greenberg"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4292 src/lifesim_lib/const.py:4420
+#: src/lifesim_lib/const.py:4301 src/lifesim_lib/const.py:4429
 msgid "Brad Pitt"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4293
+#: src/lifesim_lib/const.py:4302
 msgid "Bradley Cooper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4294
+#: src/lifesim_lib/const.py:4303
 msgid "Channing Tatum"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4295
+#: src/lifesim_lib/const.py:4304
 msgid "Clive Owen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4296
+#: src/lifesim_lib/const.py:4305
 msgid "Chace Crawford"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4297
+#: src/lifesim_lib/const.py:4306
 msgid "Cam Gigandet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4298
+#: src/lifesim_lib/const.py:4307
 msgid "Chris Brown"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4299
+#: src/lifesim_lib/const.py:4308
 msgid "Chris Pine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4300
+#: src/lifesim_lib/const.py:4309
 msgid "Chad Michael Murray"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4301
+#: src/lifesim_lib/const.py:4310
 msgid "Columbus Short"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4302
+#: src/lifesim_lib/const.py:4311
 msgid "Christian Bale"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4303
+#: src/lifesim_lib/const.py:4312
 msgid "Casey Affleck"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4304
+#: src/lifesim_lib/const.py:4313
 msgid "Cillian Murphy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4305
+#: src/lifesim_lib/const.py:4314
 msgid "Daniel Craig"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4306 src/lifesim_lib/const.py:4383
+#: src/lifesim_lib/const.py:4315 src/lifesim_lib/const.py:4392
 msgid "David Beckham"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4307
+#: src/lifesim_lib/const.py:4316
 msgid "Ed Westwick"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4308
+#: src/lifesim_lib/const.py:4317
 msgid "Eric Bana"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4309
+#: src/lifesim_lib/const.py:4318
 msgid "Emile Hirsch"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4310
+#: src/lifesim_lib/const.py:4319
 msgid "Eric Dane"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4311
+#: src/lifesim_lib/const.py:4320
 msgid "Gerard Butler"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4312
+#: src/lifesim_lib/const.py:4321
 msgid "Garrett Hedlund"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4313
+#: src/lifesim_lib/const.py:4322
 msgid "Hayden Christensen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4314
+#: src/lifesim_lib/const.py:4323
 msgid "Hugh Jackman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4315
+#: src/lifesim_lib/const.py:4324
 msgid "Hugh Laurie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4316
+#: src/lifesim_lib/const.py:4325
 msgid "Hugh Dancy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4317
+#: src/lifesim_lib/const.py:4326
 msgid "Heath Ledger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4318
+#: src/lifesim_lib/const.py:4327
 msgid "Ian Somerhalder"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4319
+#: src/lifesim_lib/const.py:4328
 msgid "James Lafferty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4320
+#: src/lifesim_lib/const.py:4329
 msgid "James Marsden"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4321 src/lifesim_lib/const.py:4408
+#: src/lifesim_lib/const.py:4330 src/lifesim_lib/const.py:4417
 msgid "John Mayer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4322
+#: src/lifesim_lib/const.py:4331
 msgid "Jude Law"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4323
+#: src/lifesim_lib/const.py:4332
 msgid "Jensen Ackles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4324
+#: src/lifesim_lib/const.py:4333
 msgid "Jake Gyllenhaal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4325
+#: src/lifesim_lib/const.py:4334
 msgid "Justin Chambers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4326
+#: src/lifesim_lib/const.py:4335
 msgid "Jesse Metcalfe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4327 src/lifesim_lib/const.py:4392
-#: src/lifesim_lib/const.py:4409
+#: src/lifesim_lib/const.py:4336 src/lifesim_lib/const.py:4401
+#: src/lifesim_lib/const.py:4418
 msgid "Justin Timberlake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4328
+#: src/lifesim_lib/const.py:4337
 msgid "Javier Bardem"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4329 src/lifesim_lib/const.py:4386
-#: src/lifesim_lib/const.py:4395 src/lifesim_lib/const.py:4421
+#: src/lifesim_lib/const.py:4338 src/lifesim_lib/const.py:4395
+#: src/lifesim_lib/const.py:4404 src/lifesim_lib/const.py:4430
 msgid "Joe Manganiello"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4330
+#: src/lifesim_lib/const.py:4339
 msgid "Johnny Depp"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4331
+#: src/lifesim_lib/const.py:4340
 msgid "James Franco"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4332
+#: src/lifesim_lib/const.py:4341
 msgid "Jack O'Connell"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4333
+#: src/lifesim_lib/const.py:4342
 msgid "Kellan Lutz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4334
+#: src/lifesim_lib/const.py:4343
 msgid "Josh Hartnett"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4335
+#: src/lifesim_lib/const.py:4344
 msgid "Jason Segel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4336
+#: src/lifesim_lib/const.py:4345
 msgid "Jared Padalecki"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4337
+#: src/lifesim_lib/const.py:4346
 msgid "Joseph Gordon-Levitt"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4338
+#: src/lifesim_lib/const.py:4347
 msgid "Liam Hemsworth"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4339
+#: src/lifesim_lib/const.py:4348
 msgid "Leonardo DiCaprio"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4340
+#: src/lifesim_lib/const.py:4349
 msgid "Luke Pasqualino"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4341
+#: src/lifesim_lib/const.py:4350
 msgid "Milo Ventimiglia"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4342
+#: src/lifesim_lib/const.py:4351
 msgid "Mark Salling"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4343
+#: src/lifesim_lib/const.py:4352
 msgid "Matthew Goode"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4344
+#: src/lifesim_lib/const.py:4353
 msgid "Mads Mikkelsen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4345
+#: src/lifesim_lib/const.py:4354
 msgid "Marshall Mathers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4346
+#: src/lifesim_lib/const.py:4355
 msgid "Mekhi Phifer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4347
+#: src/lifesim_lib/const.py:4356
 msgid "Matt Lanter"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4348
+#: src/lifesim_lib/const.py:4357
 msgid "Mike Vogel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4349
+#: src/lifesim_lib/const.py:4358
 msgid "Nick Zano"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4350
+#: src/lifesim_lib/const.py:4359
 msgid "Orlando Bloom"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4351
+#: src/lifesim_lib/const.py:4360
 msgid "Patrick Swayze"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4352
+#: src/lifesim_lib/const.py:4361
 msgid "Penn Badgley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4353
+#: src/lifesim_lib/const.py:4362
 msgid "Peter Facinelli"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4354
+#: src/lifesim_lib/const.py:4363
 msgid "Paul Walker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4355
+#: src/lifesim_lib/const.py:4364
 msgid "Ryan Gosling"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4356
+#: src/lifesim_lib/const.py:4365
 msgid "Ryan Reynolds"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4357
+#: src/lifesim_lib/const.py:4366
 msgid "Robbie Jones"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4358
+#: src/lifesim_lib/const.py:4367
 msgid "Robert Pattinson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4359
+#: src/lifesim_lib/const.py:4368
 msgid "Rick Malambri"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4360
+#: src/lifesim_lib/const.py:4369
 msgid "Ryan Kwanten"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4361
+#: src/lifesim_lib/const.py:4370
 msgid "Ryan Phillippe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4362
+#: src/lifesim_lib/const.py:4371
 msgid "Rafi Gavron"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4363
+#: src/lifesim_lib/const.py:4372
 msgid "Sam Worthington"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4364
+#: src/lifesim_lib/const.py:4373
 msgid "Sean Faris"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4365 src/lifesim_lib/const.py:4427
+#: src/lifesim_lib/const.py:4374 src/lifesim_lib/const.py:4436
 msgid "Sylvester Stallone"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4366 src/lifesim_lib/const.py:4428
+#: src/lifesim_lib/const.py:4375 src/lifesim_lib/const.py:4437
 msgid "Seth Rogan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4367
+#: src/lifesim_lib/const.py:4376
 msgid "Shia LaBeouf"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4368
+#: src/lifesim_lib/const.py:4377
 msgid "Stephen Colletti"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4369
+#: src/lifesim_lib/const.py:4378
 msgid "Shane West"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4370
+#: src/lifesim_lib/const.py:4379
 msgid "Simon Rex"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4371
+#: src/lifesim_lib/const.py:4380
 msgid "Taylor Lautner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4372
+#: src/lifesim_lib/const.py:4381
 msgid "Tom Hardy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4373 src/lifesim_lib/const.py:4410
+#: src/lifesim_lib/const.py:4382 src/lifesim_lib/const.py:4419
 msgid "Tupac Shakur"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4374
+#: src/lifesim_lib/const.py:4383
 msgid "Tristan Mack Wilds"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4375
+#: src/lifesim_lib/const.py:4384
 msgid "Timothy Olyphant"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4376
+#: src/lifesim_lib/const.py:4385
 msgid "Tom Welling"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4377
+#: src/lifesim_lib/const.py:4386
 msgid "Travis Barker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4378
+#: src/lifesim_lib/const.py:4387
 msgid "Wentworth Miller"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4379
+#: src/lifesim_lib/const.py:4388
 msgid "Zac Efron"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4389
+#: src/lifesim_lib/const.py:4398
 msgid "Elon Musk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4402
+#: src/lifesim_lib/const.py:4411
 msgid "David Gandy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4403
+#: src/lifesim_lib/const.py:4412
 msgid "Sean O'Pry"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4407
+#: src/lifesim_lib/const.py:4416
 msgid "Jared Followill"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4416
+#: src/lifesim_lib/const.py:4425
 msgid "James Deen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4424
+#: src/lifesim_lib/const.py:4433
 msgid "Prince Carl Philip of Sweden, Duke of Värmland"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4434
+#: src/lifesim_lib/const.py:4443
 msgid "Zach King"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4437
+#: src/lifesim_lib/const.py:4446
 msgid "Randy Orton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4440
+#: src/lifesim_lib/const.py:4449
 msgid "Stan Lee"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4444 src/lifesim_lib/const.py:4565
+#: src/lifesim_lib/const.py:4453 src/lifesim_lib/const.py:4574
 msgid "Adriana Lima"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4445 src/lifesim_lib/const.py:4566
+#: src/lifesim_lib/const.py:4454 src/lifesim_lib/const.py:4575
 msgid "Aishwarya Rai Bachchan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4446 src/lifesim_lib/const.py:4567
+#: src/lifesim_lib/const.py:4455 src/lifesim_lib/const.py:4576
 msgid "Alessandra Ambrosio"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4447
+#: src/lifesim_lib/const.py:4456
 msgid "Amber Heard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4448 src/lifesim_lib/const.py:4568
+#: src/lifesim_lib/const.py:4457 src/lifesim_lib/const.py:4577
 msgid "Ana Beatriz Barros"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4449
+#: src/lifesim_lib/const.py:4458
 msgid "Anna Paquin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4450
+#: src/lifesim_lib/const.py:4459
 msgid "AnnaSophia Robb"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4451 src/lifesim_lib/const.py:4569
+#: src/lifesim_lib/const.py:4460 src/lifesim_lib/const.py:4578
 msgid "Anne Vyalitsyna"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4452
+#: src/lifesim_lib/const.py:4461
 msgid "Angelina Jolie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4453 src/lifesim_lib/const.py:4554
-#: src/lifesim_lib/const.py:4608
+#: src/lifesim_lib/const.py:4462 src/lifesim_lib/const.py:4563
+#: src/lifesim_lib/const.py:4617
 msgid "Ashley Benson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4454
+#: src/lifesim_lib/const.py:4463
 msgid "Ashley Greene"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4455 src/lifesim_lib/const.py:4570
+#: src/lifesim_lib/const.py:4464 src/lifesim_lib/const.py:4579
 msgid "Bar Refaeli"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4456 src/lifesim_lib/const.py:4571
+#: src/lifesim_lib/const.py:4465 src/lifesim_lib/const.py:4580
 msgid "Behati Prinsloo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4457 src/lifesim_lib/const.py:4609
+#: src/lifesim_lib/const.py:4466 src/lifesim_lib/const.py:4618
 msgid "Beyoncé Knowles"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4458
+#: src/lifesim_lib/const.py:4467
 msgid "Blake Lively"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4459 src/lifesim_lib/const.py:4572
+#: src/lifesim_lib/const.py:4468 src/lifesim_lib/const.py:4581
 msgid "Brooklyn Decker"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4460 src/lifesim_lib/const.py:4573
+#: src/lifesim_lib/const.py:4469 src/lifesim_lib/const.py:4582
 msgid "Candice Swanepoel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4461 src/lifesim_lib/const.py:4555
-#: src/lifesim_lib/const.py:4574 src/lifesim_lib/const.py:4610
+#: src/lifesim_lib/const.py:4470 src/lifesim_lib/const.py:4564
+#: src/lifesim_lib/const.py:4583 src/lifesim_lib/const.py:4619
 msgid "Cassie Ventura"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4462 src/lifesim_lib/const.py:4626
+#: src/lifesim_lib/const.py:4471 src/lifesim_lib/const.py:4635
 msgid "Charlize Theron"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4463 src/lifesim_lib/const.py:4611
+#: src/lifesim_lib/const.py:4472 src/lifesim_lib/const.py:4620
 msgid "Cheryl Cole"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4464
+#: src/lifesim_lib/const.py:4473
 msgid "Chloë Grace Moretz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4465 src/lifesim_lib/const.py:4575
-#: src/lifesim_lib/const.py:4627
+#: src/lifesim_lib/const.py:4474 src/lifesim_lib/const.py:4584
+#: src/lifesim_lib/const.py:4636
 msgid "Cindy Crawford"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4466 src/lifesim_lib/const.py:4550
-#: src/lifesim_lib/const.py:4612
+#: src/lifesim_lib/const.py:4475 src/lifesim_lib/const.py:4559
+#: src/lifesim_lib/const.py:4621
 msgid "Demi Lovato"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4467 src/lifesim_lib/const.py:4576
+#: src/lifesim_lib/const.py:4476 src/lifesim_lib/const.py:4585
 msgid "Denise Richards"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4468
+#: src/lifesim_lib/const.py:4477
 msgid "Diane Kruger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4469 src/lifesim_lib/const.py:4577
+#: src/lifesim_lib/const.py:4478 src/lifesim_lib/const.py:4586
 msgid "Doutzen Kroes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4470 src/lifesim_lib/const.py:4578
+#: src/lifesim_lib/const.py:4479 src/lifesim_lib/const.py:4587
 msgid "Elisha Cuthbert"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4471
+#: src/lifesim_lib/const.py:4480
 msgid "Emilia Clarke"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4472
+#: src/lifesim_lib/const.py:4481
 msgid "Emily Blunt"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4473
+#: src/lifesim_lib/const.py:4482
 msgid "Emma Stone"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4474
+#: src/lifesim_lib/const.py:4483
 msgid "Emma Watson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4475
+#: src/lifesim_lib/const.py:4484
 msgid "Erin Heatherton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4476 src/lifesim_lib/const.py:4579
+#: src/lifesim_lib/const.py:4485 src/lifesim_lib/const.py:4588
 msgid "Eva Green"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4477
+#: src/lifesim_lib/const.py:4486
 msgid "Eva Longoria"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4478
+#: src/lifesim_lib/const.py:4487
 msgid "Eva Mendes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4479
+#: src/lifesim_lib/const.py:4488
 msgid "Freida Pinto"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4480 src/lifesim_lib/const.py:4580
+#: src/lifesim_lib/const.py:4489 src/lifesim_lib/const.py:4589
 msgid "Gisele Bündchen"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4481
+#: src/lifesim_lib/const.py:4490
 msgid "Hilary Duff"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4482 src/lifesim_lib/const.py:4613
+#: src/lifesim_lib/const.py:4491 src/lifesim_lib/const.py:4622
 msgid "Indiana Evans"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4483 src/lifesim_lib/const.py:4581
+#: src/lifesim_lib/const.py:4492 src/lifesim_lib/const.py:4590
 msgid "Irina Shayk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4484
+#: src/lifesim_lib/const.py:4493
 msgid "Isabel Lucas"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4485 src/lifesim_lib/const.py:4582
+#: src/lifesim_lib/const.py:4494 src/lifesim_lib/const.py:4591
 msgid "Izabel Goulart"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4486 src/lifesim_lib/const.py:4556
-#: src/lifesim_lib/const.py:4583
+#: src/lifesim_lib/const.py:4495 src/lifesim_lib/const.py:4565
+#: src/lifesim_lib/const.py:4592
 msgid "Jenna Dewan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4487
+#: src/lifesim_lib/const.py:4496
 msgid "Jennifer Lawrence"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4488
+#: src/lifesim_lib/const.py:4497
 msgid "Jessica Alba"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4489
+#: src/lifesim_lib/const.py:4498
 msgid "Jessica Biel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4490
+#: src/lifesim_lib/const.py:4499
 msgid "Jordana Brewster"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4491 src/lifesim_lib/const.py:4584
+#: src/lifesim_lib/const.py:4500 src/lifesim_lib/const.py:4593
 msgid "Josie Maran"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4492 src/lifesim_lib/const.py:4585
+#: src/lifesim_lib/const.py:4501 src/lifesim_lib/const.py:4594
 msgid "Karolina Kurkova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4493
+#: src/lifesim_lib/const.py:4502
 msgid "Kate Beckinsale"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4494 src/lifesim_lib/const.py:4586
+#: src/lifesim_lib/const.py:4503 src/lifesim_lib/const.py:4595
 msgid "Kate Upton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4495
+#: src/lifesim_lib/const.py:4504
 msgid "Katie Holmes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4496
+#: src/lifesim_lib/const.py:4505
 msgid "Keira Knightley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4497 src/lifesim_lib/const.py:4587
+#: src/lifesim_lib/const.py:4506 src/lifesim_lib/const.py:4596
 msgid "Kelly Brook"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4498 src/lifesim_lib/const.py:4588
+#: src/lifesim_lib/const.py:4507 src/lifesim_lib/const.py:4597
 msgid "Kendall Jenner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4499 src/lifesim_lib/const.py:4561
-#: src/lifesim_lib/const.py:4651
+#: src/lifesim_lib/const.py:4508 src/lifesim_lib/const.py:4570
+#: src/lifesim_lib/const.py:4660
 msgid "Kim Kardashian"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4500
+#: src/lifesim_lib/const.py:4509
 msgid "Kristen Stewart"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4501
+#: src/lifesim_lib/const.py:4510
 msgid "Kristin Kreuk"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4502 src/lifesim_lib/const.py:4589
+#: src/lifesim_lib/const.py:4511 src/lifesim_lib/const.py:4598
 msgid "Laetitia Casta"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4503
+#: src/lifesim_lib/const.py:4512
 msgid "Lauren Conrad"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4504 src/lifesim_lib/const.py:4590
+#: src/lifesim_lib/const.py:4513 src/lifesim_lib/const.py:4599
 msgid "Lily Aldridge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4505
+#: src/lifesim_lib/const.py:4514
 msgid "Lucy Hale"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4506 src/lifesim_lib/const.py:4628
+#: src/lifesim_lib/const.py:4515 src/lifesim_lib/const.py:4637
 msgid "Marion Cotillard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4507 src/lifesim_lib/const.py:4637
+#: src/lifesim_lib/const.py:4516 src/lifesim_lib/const.py:4646
 msgid "Nikki Reed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4508
+#: src/lifesim_lib/const.py:4517
 msgid "Nina Dobrev"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4509
+#: src/lifesim_lib/const.py:4518
 msgid "Olivia Wilde"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4510 src/lifesim_lib/const.py:4591
+#: src/lifesim_lib/const.py:4519 src/lifesim_lib/const.py:4600
 msgid "Malin Akerman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4511 src/lifesim_lib/const.py:4592
+#: src/lifesim_lib/const.py:4520 src/lifesim_lib/const.py:4601
 msgid "Marisa Miller"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4512
+#: src/lifesim_lib/const.py:4521
 msgid "Megan Fox"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4513 src/lifesim_lib/const.py:4614
+#: src/lifesim_lib/const.py:4522 src/lifesim_lib/const.py:4623
 msgid "Minka Kelly"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4514
+#: src/lifesim_lib/const.py:4523
 msgid "Mila Kunis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4515 src/lifesim_lib/const.py:4593
+#: src/lifesim_lib/const.py:4524 src/lifesim_lib/const.py:4602
 msgid "Miranda Kerr"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4516 src/lifesim_lib/const.py:4594
+#: src/lifesim_lib/const.py:4525 src/lifesim_lib/const.py:4603
 msgid "Monica Bellucci"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4517 src/lifesim_lib/const.py:4595
-#: src/lifesim_lib/const.py:4641
+#: src/lifesim_lib/const.py:4526 src/lifesim_lib/const.py:4604
+#: src/lifesim_lib/const.py:4650
 msgid "Natalia Vodianova"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4518
+#: src/lifesim_lib/const.py:4527
 msgid "Natalie Portman"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4519
+#: src/lifesim_lib/const.py:4528
 msgid "Nicole Scherzinger"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4520 src/lifesim_lib/const.py:4596
-#: src/lifesim_lib/const.py:4645
+#: src/lifesim_lib/const.py:4529 src/lifesim_lib/const.py:4605
+#: src/lifesim_lib/const.py:4654
 msgid "Olivia Culpo"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4521
+#: src/lifesim_lib/const.py:4530
 msgid "Penélope Cruz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4522
+#: src/lifesim_lib/const.py:4531
 msgid "Rachel Bilson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4523
+#: src/lifesim_lib/const.py:4532
 msgid "Rachel McAdams"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4524 src/lifesim_lib/const.py:4597
+#: src/lifesim_lib/const.py:4533 src/lifesim_lib/const.py:4606
 msgid "Rachael Taylor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4525
+#: src/lifesim_lib/const.py:4534
 msgid "Rachel Weisz"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4526 src/lifesim_lib/const.py:4562
-#: src/lifesim_lib/const.py:4615
+#: src/lifesim_lib/const.py:4535 src/lifesim_lib/const.py:4571
+#: src/lifesim_lib/const.py:4624
 msgid "Rihanna Fenty"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4527 src/lifesim_lib/const.py:4557
-#: src/lifesim_lib/const.py:4598 src/lifesim_lib/const.py:4616
-#: src/lifesim_lib/const.py:4629 src/lifesim_lib/const.py:4652
+#: src/lifesim_lib/const.py:4536 src/lifesim_lib/const.py:4566
+#: src/lifesim_lib/const.py:4607 src/lifesim_lib/const.py:4625
+#: src/lifesim_lib/const.py:4638 src/lifesim_lib/const.py:4661
 msgid "Roselyn Sanchez"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4528 src/lifesim_lib/const.py:4599
+#: src/lifesim_lib/const.py:4537 src/lifesim_lib/const.py:4608
 msgid "Rosie Huntington-Whiteley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4529
+#: src/lifesim_lib/const.py:4538
 msgid "Salma Hayek"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4530
+#: src/lifesim_lib/const.py:4539
 msgid "Sara Carbonero"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4531
+#: src/lifesim_lib/const.py:4540
 msgid "Scarlett Johansson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4532 src/lifesim_lib/const.py:4617
-#: src/lifesim_lib/const.py:4630
+#: src/lifesim_lib/const.py:4541 src/lifesim_lib/const.py:4626
+#: src/lifesim_lib/const.py:4639
 msgid "Selena Gomez"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4533
+#: src/lifesim_lib/const.py:4542
 msgid "Shanina Shaik"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4534 src/lifesim_lib/const.py:4600
-#: src/lifesim_lib/const.py:4653
+#: src/lifesim_lib/const.py:4543 src/lifesim_lib/const.py:4609
+#: src/lifesim_lib/const.py:4662
 msgid "Shay Mitchell"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4535 src/lifesim_lib/const.py:4601
+#: src/lifesim_lib/const.py:4544 src/lifesim_lib/const.py:4610
 msgid "Sienna Miller"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4536 src/lifesim_lib/const.py:4547
-#: src/lifesim_lib/const.py:4602
+#: src/lifesim_lib/const.py:4545 src/lifesim_lib/const.py:4556
+#: src/lifesim_lib/const.py:4611
 msgid "Sofía Vergara"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4537 src/lifesim_lib/const.py:4551
-#: src/lifesim_lib/const.py:4558 src/lifesim_lib/const.py:4603
-#: src/lifesim_lib/const.py:4648
+#: src/lifesim_lib/const.py:4546 src/lifesim_lib/const.py:4560
+#: src/lifesim_lib/const.py:4567 src/lifesim_lib/const.py:4612
+#: src/lifesim_lib/const.py:4657
 msgid "Stacy Keibler"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4538 src/lifesim_lib/const.py:4604
-#: src/lifesim_lib/const.py:4631 src/lifesim_lib/const.py:4654
+#: src/lifesim_lib/const.py:4547 src/lifesim_lib/const.py:4613
+#: src/lifesim_lib/const.py:4640 src/lifesim_lib/const.py:4663
 msgid "Tyra Banks"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4539
+#: src/lifesim_lib/const.py:4548
 msgid "Vanessa Hudgens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4540 src/lifesim_lib/const.py:4605
+#: src/lifesim_lib/const.py:4549 src/lifesim_lib/const.py:4614
 msgid "Ximena Navarrete"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4541
+#: src/lifesim_lib/const.py:4550
 msgid "Zoe Saldana"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4544
+#: src/lifesim_lib/const.py:4553
 msgid "Serena Williams"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4620
+#: src/lifesim_lib/const.py:4629
 msgid "Hillary Clinton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4623
+#: src/lifesim_lib/const.py:4632
 msgid "Jenna Jameson"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4634 src/lifesim_lib/const.py:4640
+#: src/lifesim_lib/const.py:4643 src/lifesim_lib/const.py:4649
 msgid "Catherine Middleton, Princess of Wales"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4642
+#: src/lifesim_lib/const.py:4651
 msgid "Pippa Middleton"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4657
+#: src/lifesim_lib/const.py:4666
 msgid "The Backstreet Boys"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4668
+#: src/lifesim_lib/const.py:4677
 msgid "an abandoned building"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4669
+#: src/lifesim_lib/const.py:4678
 msgid "an abandoned factory"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4670
+#: src/lifesim_lib/const.py:4679
 msgid "an abandoned house"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4671
+#: src/lifesim_lib/const.py:4680
 msgid "an abandoned office building"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4672
+#: src/lifesim_lib/const.py:4681
 msgid "an abandoned school"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4673
+#: src/lifesim_lib/const.py:4682
 msgid "an airport"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4674
+#: src/lifesim_lib/const.py:4683
 msgid "an airfield"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4675
+#: src/lifesim_lib/const.py:4684
 msgid "an alleyway"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4676
+#: src/lifesim_lib/const.py:4685
 msgid "an ambulance station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4677
+#: src/lifesim_lib/const.py:4686
 msgid "an apartment building"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4678
+#: src/lifesim_lib/const.py:4687
 msgid "an aquarium"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4679
+#: src/lifesim_lib/const.py:4688
 msgid "an arcade"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4680
+#: src/lifesim_lib/const.py:4689
 msgid "an art gallery"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4681
+#: src/lifesim_lib/const.py:4690
 msgid "an avenue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4682
+#: src/lifesim_lib/const.py:4691
 msgid "a bakery"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4683
+#: src/lifesim_lib/const.py:4692
 msgid "a bank"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4684
+#: src/lifesim_lib/const.py:4693
 msgid "a bar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4685
+#: src/lifesim_lib/const.py:4694
 msgid "a barber shop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4686
+#: src/lifesim_lib/const.py:4695
 msgid "a beauty salon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4687
+#: src/lifesim_lib/const.py:4696
 msgid "a bed & breakfast"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4688
+#: src/lifesim_lib/const.py:4697
 msgid "a bicycle rental stand"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4689
+#: src/lifesim_lib/const.py:4698
 msgid "a billboard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4690
+#: src/lifesim_lib/const.py:4699
 msgid "a bookstore"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4691
+#: src/lifesim_lib/const.py:4700
 msgid "a boulevard"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4692
+#: src/lifesim_lib/const.py:4701
 msgid "a bowling alley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4693
+#: src/lifesim_lib/const.py:4702
 msgid "a bridge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4694
+#: src/lifesim_lib/const.py:4703
 msgid "a bus stop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4695
+#: src/lifesim_lib/const.py:4704
 msgid "a butcher's shop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4696
+#: src/lifesim_lib/const.py:4705
 msgid "a cafe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4697
+#: src/lifesim_lib/const.py:4706
 msgid "a canal"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4698
+#: src/lifesim_lib/const.py:4707
 msgid "the central business district"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4699
+#: src/lifesim_lib/const.py:4708
 msgid "a church"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4700
+#: src/lifesim_lib/const.py:4709
 msgid "City Hall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4701
+#: src/lifesim_lib/const.py:4710
 msgid "a clinic"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4702
+#: src/lifesim_lib/const.py:4711
 msgid "a coffee shop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4703
+#: src/lifesim_lib/const.py:4712
 msgid "a college"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4704
+#: src/lifesim_lib/const.py:4713
 msgid "a community centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4705
+#: src/lifesim_lib/const.py:4714
 msgid "a community gardens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4706
+#: src/lifesim_lib/const.py:4715
 msgid "a concert hall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4707
+#: src/lifesim_lib/const.py:4716
 msgid "a condominium"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4708
+#: src/lifesim_lib/const.py:4717
 msgid "a construction site"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4709
+#: src/lifesim_lib/const.py:4718
 msgid "a convenience store"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4710
+#: src/lifesim_lib/const.py:4719
 msgid "a court"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4711
+#: src/lifesim_lib/const.py:4720
 msgid "a cycle highway"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4712
+#: src/lifesim_lib/const.py:4721
 msgid "a daycare centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4713
+#: src/lifesim_lib/const.py:4722
 msgid "a dentist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4714
+#: src/lifesim_lib/const.py:4723
 msgid "a department store"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4715
+#: src/lifesim_lib/const.py:4724
 msgid "a dock"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4716
+#: src/lifesim_lib/const.py:4725
 msgid "the docks"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4717
+#: src/lifesim_lib/const.py:4726
 msgid "a doctor's office"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4718
+#: src/lifesim_lib/const.py:4727
 msgid "some drainage infrastructure"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4719
+#: src/lifesim_lib/const.py:4728
 msgid "a dry cleaner"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4720
+#: src/lifesim_lib/const.py:4729
 msgid "an embassy"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4721
+#: src/lifesim_lib/const.py:4730
 msgid "a factory"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4722
+#: src/lifesim_lib/const.py:4731
 msgid "a fire hydrant"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4723
+#: src/lifesim_lib/const.py:4732
 msgid "a fire station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4724
+#: src/lifesim_lib/const.py:4733
 msgid "a flower shop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4725
+#: src/lifesim_lib/const.py:4734
 msgid "a garbage facility"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4726
+#: src/lifesim_lib/const.py:4735
 msgid "a garden"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4727
+#: src/lifesim_lib/const.py:4736
 msgid "a gardens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4728
+#: src/lifesim_lib/const.py:4737
 msgid "a government building"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4729
+#: src/lifesim_lib/const.py:4738
 msgid "a green-roof"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4730
+#: src/lifesim_lib/const.py:4739
 msgid "a grocery store"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4731
+#: src/lifesim_lib/const.py:4740
 msgid "a greengrocer"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4732
+#: src/lifesim_lib/const.py:4741
 msgid "a gym"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4733
+#: src/lifesim_lib/const.py:4742
 msgid "a gymnasium"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4734
+#: src/lifesim_lib/const.py:4743
 msgid "a harbour"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4735
+#: src/lifesim_lib/const.py:4744
 msgid "the harbour"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4736
+#: src/lifesim_lib/const.py:4745
 msgid "a highway"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4737
+#: src/lifesim_lib/const.py:4746
 msgid "a historical building"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4738
+#: src/lifesim_lib/const.py:4747
 msgid "a historical site"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4739
+#: src/lifesim_lib/const.py:4748
 msgid "a hospital"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4740
+#: src/lifesim_lib/const.py:4749
 msgid "a hotel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4741
+#: src/lifesim_lib/const.py:4750
 msgid "a house"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4742
+#: src/lifesim_lib/const.py:4751
 msgid "a jail"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4743
+#: src/lifesim_lib/const.py:4752
 msgid "a karaoke bar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4744
+#: src/lifesim_lib/const.py:4753
 msgid "a karaoke lounge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4745
+#: src/lifesim_lib/const.py:4754
 msgid "a landmark"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4746
+#: src/lifesim_lib/const.py:4755
 msgid "a laundromat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4747
+#: src/lifesim_lib/const.py:4756
 msgid "a library"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4748
+#: src/lifesim_lib/const.py:4757
 msgid "a linear park"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4749
+#: src/lifesim_lib/const.py:4758
 msgid "a market"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4750
+#: src/lifesim_lib/const.py:4759
 msgid "the markets"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4751
+#: src/lifesim_lib/const.py:4760
 msgid "a mixed-use building"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4752
+#: src/lifesim_lib/const.py:4761
 msgid "a mixed-use street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4753
+#: src/lifesim_lib/const.py:4762
 msgid "a monument"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4754
+#: src/lifesim_lib/const.py:4763
 msgid "a movie theatre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4755
+#: src/lifesim_lib/const.py:4764
 msgid "a museum"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4756
+#: src/lifesim_lib/const.py:4765
 msgid "a music festival"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4757
+#: src/lifesim_lib/const.py:4766
 msgid "a nature reserve"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4758
+#: src/lifesim_lib/const.py:4767
 msgid "a newspaper office"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4759
+#: src/lifesim_lib/const.py:4768
 msgid "some night architecture"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4760
+#: src/lifesim_lib/const.py:4769
 msgid "a nightclub"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4761
+#: src/lifesim_lib/const.py:4770
 msgid "a nursery school"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4762
+#: src/lifesim_lib/const.py:4771
 msgid "a nursing home"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4763
+#: src/lifesim_lib/const.py:4772
 msgid "an observatory"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4764
+#: src/lifesim_lib/const.py:4773
 msgid "an office building"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4765
+#: src/lifesim_lib/const.py:4774
 msgid "an opera house"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4766
+#: src/lifesim_lib/const.py:4775
 msgid "some outdoor seating"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4767
+#: src/lifesim_lib/const.py:4776
 msgid "an overpass"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4768
+#: src/lifesim_lib/const.py:4777
 msgid "a park"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4769
+#: src/lifesim_lib/const.py:4778
 msgid "a patisserie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4770
+#: src/lifesim_lib/const.py:4779
 msgid "some pedestrian infrastructure"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4771
+#: src/lifesim_lib/const.py:4780
 msgid "a performance theatre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4772
+#: src/lifesim_lib/const.py:4781
 msgid "a pharmacist"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4773
+#: src/lifesim_lib/const.py:4782
 msgid "a place of worship"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4774
+#: src/lifesim_lib/const.py:4783
 msgid "a play street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4775
+#: src/lifesim_lib/const.py:4784
 msgid "a playground"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4776
+#: src/lifesim_lib/const.py:4785
 msgid "a police station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4777 src/lifesim_lib/const.py:4997
+#: src/lifesim_lib/const.py:4786 src/lifesim_lib/const.py:5006
 msgid "a pond"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4778
+#: src/lifesim_lib/const.py:4787
 msgid "a port"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4779
+#: src/lifesim_lib/const.py:4788
 msgid "the port"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4780
+#: src/lifesim_lib/const.py:4789
 msgid "a post office"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4781
+#: src/lifesim_lib/const.py:4790
 msgid "a prison"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4782
+#: src/lifesim_lib/const.py:4791
 msgid "a product showroom"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4783
+#: src/lifesim_lib/const.py:4792
 msgid "a pub"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4784
+#: src/lifesim_lib/const.py:4793
 msgid "a public bath"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4785
+#: src/lifesim_lib/const.py:4794
 msgid "a public pool"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4786
+#: src/lifesim_lib/const.py:4795
 msgid "a public square"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4787
+#: src/lifesim_lib/const.py:4796
 msgid "a public toilet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4788
+#: src/lifesim_lib/const.py:4797
 msgid "a radio station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4789
+#: src/lifesim_lib/const.py:4798
 msgid "a railway line"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4790
+#: src/lifesim_lib/const.py:4799
 msgid "a railway station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4791
+#: src/lifesim_lib/const.py:4800
 msgid "a recreation centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4792
+#: src/lifesim_lib/const.py:4801
 msgid "a recreation facility"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4793
+#: src/lifesim_lib/const.py:4802
 msgid "some remarkable architecture"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4794
+#: src/lifesim_lib/const.py:4803
 msgid "a restaurant"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4795 src/lifesim_lib/const.py:5008
+#: src/lifesim_lib/const.py:4804 src/lifesim_lib/const.py:5017
 msgid "a river"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4796
+#: src/lifesim_lib/const.py:4805
 msgid "a school"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4797
+#: src/lifesim_lib/const.py:4806
 msgid "the sewers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4798
+#: src/lifesim_lib/const.py:4807
 msgid "a shoe store"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4799
+#: src/lifesim_lib/const.py:4808
 msgid "a shopping centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4800
+#: src/lifesim_lib/const.py:4809
 msgid "a shopping mall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4801
+#: src/lifesim_lib/const.py:4810
 msgid "a shop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4802
+#: src/lifesim_lib/const.py:4811
 msgid "a skating rink"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4803
+#: src/lifesim_lib/const.py:4812
 msgid "a skyscraper"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4804
+#: src/lifesim_lib/const.py:4813
 msgid "a spa"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4805
+#: src/lifesim_lib/const.py:4814
 msgid "a sports facility"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4806
+#: src/lifesim_lib/const.py:4815
 msgid "a sports shop"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4807
+#: src/lifesim_lib/const.py:4816
 msgid "a sports stadium"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4808
+#: src/lifesim_lib/const.py:4817
 msgid "a sports store"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4809
+#: src/lifesim_lib/const.py:4818
 msgid "a stadium"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4810 src/lifesim_lib/const.py:5024
+#: src/lifesim_lib/const.py:4819 src/lifesim_lib/const.py:5033
 msgid "a stream"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4811
+#: src/lifesim_lib/const.py:4820
 msgid "a street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4812
+#: src/lifesim_lib/const.py:4821
 msgid "some street art"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4813
+#: src/lifesim_lib/const.py:4822
 msgid "a street food vendor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4814
+#: src/lifesim_lib/const.py:4823
 msgid "a street vendor"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4815
+#: src/lifesim_lib/const.py:4824
 msgid "a street light"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4816
+#: src/lifesim_lib/const.py:4825
 msgid "some street lights"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4817
+#: src/lifesim_lib/const.py:4826
 msgid "a strip of shops"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4818
+#: src/lifesim_lib/const.py:4827
 msgid "a subway station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4819
+#: src/lifesim_lib/const.py:4828
 msgid "a swimming pool"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4820
+#: src/lifesim_lib/const.py:4829
 msgid "a synagogue"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4821
+#: src/lifesim_lib/const.py:4830
 msgid "a taxi stand"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4822
+#: src/lifesim_lib/const.py:4831
 msgid "a technology centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4823
+#: src/lifesim_lib/const.py:4832
 msgid "some tech infrastructure"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4824
+#: src/lifesim_lib/const.py:4833
 msgid "a television station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4825
+#: src/lifesim_lib/const.py:4834
 msgid "a tennis court"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4826
+#: src/lifesim_lib/const.py:4835
 msgid "a temple"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4827
+#: src/lifesim_lib/const.py:4836
 msgid "a temple complex"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4828
+#: src/lifesim_lib/const.py:4837
 msgid "a theme park"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4829
+#: src/lifesim_lib/const.py:4838
 msgid "a tower"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4830
+#: src/lifesim_lib/const.py:4839
 msgid "a traffic light"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4831
+#: src/lifesim_lib/const.py:4840
 msgid "some traffic lights"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4832
+#: src/lifesim_lib/const.py:4841
 msgid "a train line"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4833
+#: src/lifesim_lib/const.py:4842
 msgid "a train station"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4834
+#: src/lifesim_lib/const.py:4843
 msgid "a tree"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4835
+#: src/lifesim_lib/const.py:4844
 msgid "some trees"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4836
+#: src/lifesim_lib/const.py:4845
 msgid "the underground"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4837
+#: src/lifesim_lib/const.py:4846
 msgid "an underpass"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4838
+#: src/lifesim_lib/const.py:4847
 msgid "a university"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4839
+#: src/lifesim_lib/const.py:4848
 msgid "an urban farm"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4840
+#: src/lifesim_lib/const.py:4849
 msgid "an urban forest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4841
+#: src/lifesim_lib/const.py:4850
 msgid "a vending machine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4842
+#: src/lifesim_lib/const.py:4851
 msgid "some vending machines"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4843
+#: src/lifesim_lib/const.py:4852
 msgid "a vertical park"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4844
+#: src/lifesim_lib/const.py:4853
 msgid "a visitor centre"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4845
+#: src/lifesim_lib/const.py:4854
 msgid "a void deck"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4846
+#: src/lifesim_lib/const.py:4855
 msgid "a water pipe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4847
+#: src/lifesim_lib/const.py:4856
 msgid "some water pipes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4848
+#: src/lifesim_lib/const.py:4857
 msgid "a water tower"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4849
+#: src/lifesim_lib/const.py:4858
 msgid "a waterfront"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4850
+#: src/lifesim_lib/const.py:4859
 msgid "the waterfront"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4851
+#: src/lifesim_lib/const.py:4860
 msgid "a waterfront tower"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4860
+#: src/lifesim_lib/const.py:4869
 msgid "across the river"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4861
+#: src/lifesim_lib/const.py:4870
 msgid "across town"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4862
+#: src/lifesim_lib/const.py:4871
 msgid "downtown"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4863
+#: src/lifesim_lib/const.py:4872
 msgid "down the road"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4864
+#: src/lifesim_lib/const.py:4873
 msgid "over the road"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4865
+#: src/lifesim_lib/const.py:4874
 msgid "up the road"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4866
+#: src/lifesim_lib/const.py:4875
 msgid "up the street"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4874
+#: src/lifesim_lib/const.py:4883
 msgid "caught the bus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4875
+#: src/lifesim_lib/const.py:4884
 msgid "hiked"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4876
+#: src/lifesim_lib/const.py:4885
 msgid "hitch-hiked"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4877
+#: src/lifesim_lib/const.py:4886
 msgid "jogged"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4878
+#: src/lifesim_lib/const.py:4887
 msgid "knocked about"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4879
+#: src/lifesim_lib/const.py:4888
 msgid "legged it"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4880
+#: src/lifesim_lib/const.py:4889
 msgid "meandered"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4881
+#: src/lifesim_lib/const.py:4890
 msgid "ran"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4882
+#: src/lifesim_lib/const.py:4891
 msgid "rode"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4883
+#: src/lifesim_lib/const.py:4892
 msgid "rowed a boat"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4884
+#: src/lifesim_lib/const.py:4893
 msgid "skated"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4885
+#: src/lifesim_lib/const.py:4894
 msgid "took a bus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4886
+#: src/lifesim_lib/const.py:4895
 msgid "took a cab"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4887
+#: src/lifesim_lib/const.py:4896
 msgid "took a taxi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4888
+#: src/lifesim_lib/const.py:4897
 msgid "took the train"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4889
+#: src/lifesim_lib/const.py:4898
 msgid "took a water taxi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4890
+#: src/lifesim_lib/const.py:4899
 msgid "walked"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4891
+#: src/lifesim_lib/const.py:4900
 msgid "went jogging"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4897
+#: src/lifesim_lib/const.py:4906
 msgid "a barn"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4898
+#: src/lifesim_lib/const.py:4907
 msgid "a campsite"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4899
+#: src/lifesim_lib/const.py:4908
 msgid "a country lane"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4900
+#: src/lifesim_lib/const.py:4909
 msgid "a country music festival"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4901
+#: src/lifesim_lib/const.py:4910
 msgid "a dam"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4902
+#: src/lifesim_lib/const.py:4911
 msgid "a farm"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4903
+#: src/lifesim_lib/const.py:4912
 msgid "a field"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4904
+#: src/lifesim_lib/const.py:4913
 msgid "a fish farm"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4905
+#: src/lifesim_lib/const.py:4914
 msgid "a paddock"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4906
+#: src/lifesim_lib/const.py:4915
 msgid "a hay shed"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4907
+#: src/lifesim_lib/const.py:4916
 msgid "a wildlife preserve"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4908
+#: src/lifesim_lib/const.py:4917
 msgid "a windmill"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4914
+#: src/lifesim_lib/const.py:4923
 msgid "an alluvial fan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4915
+#: src/lifesim_lib/const.py:4924
 msgid "an archipelago"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4916
+#: src/lifesim_lib/const.py:4925
 msgid "the archipelago"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4917
+#: src/lifesim_lib/const.py:4926
 msgid "an atoll"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4918
+#: src/lifesim_lib/const.py:4927
 msgid "a sand bar"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4919
+#: src/lifesim_lib/const.py:4928
 msgid "a barchan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4920
+#: src/lifesim_lib/const.py:4929
 msgid "a basin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4921
+#: src/lifesim_lib/const.py:4930
 msgid "the bay"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4922
+#: src/lifesim_lib/const.py:4931
 msgid "a coastal bay"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4923
+#: src/lifesim_lib/const.py:4932
 msgid "the bayside"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4924
+#: src/lifesim_lib/const.py:4933
 msgid "a beach"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4925
+#: src/lifesim_lib/const.py:4934
 msgid "the beach"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4926
+#: src/lifesim_lib/const.py:4935
 msgid "a butte"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4927
+#: src/lifesim_lib/const.py:4936
 msgid "the buttes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4928
+#: src/lifesim_lib/const.py:4937
 msgid "a cape"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4929
+#: src/lifesim_lib/const.py:4938
 msgid "a canyon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4930
+#: src/lifesim_lib/const.py:4939
 msgid "the canyon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4931
+#: src/lifesim_lib/const.py:4940
 msgid "a cave"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4932
+#: src/lifesim_lib/const.py:4941
 msgid "the caves"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4933
+#: src/lifesim_lib/const.py:4942
 msgid "a channel"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4934
+#: src/lifesim_lib/const.py:4943
 msgid "a cliff"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4935
+#: src/lifesim_lib/const.py:4944
 msgid "the cliffs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4936
+#: src/lifesim_lib/const.py:4945
 msgid "the coast"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4937
+#: src/lifesim_lib/const.py:4946
 msgid "a desert"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4938
+#: src/lifesim_lib/const.py:4947
 msgid "the desert"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4939
+#: src/lifesim_lib/const.py:4948
 msgid "a divide"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4940
+#: src/lifesim_lib/const.py:4949
 msgid "a dune"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4941
+#: src/lifesim_lib/const.py:4950
 msgid "a crescent dune"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4942
+#: src/lifesim_lib/const.py:4951
 msgid "a sand dune"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4943
+#: src/lifesim_lib/const.py:4952
 msgid "a geyser"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4944
+#: src/lifesim_lib/const.py:4953
 msgid "the geysers"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4945
+#: src/lifesim_lib/const.py:4954
 msgid "a glacier"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4946
+#: src/lifesim_lib/const.py:4955
 msgid "a gorge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4947
+#: src/lifesim_lib/const.py:4956
 msgid "the gorge"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4948
+#: src/lifesim_lib/const.py:4957
 msgid "the grasslands"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4949
+#: src/lifesim_lib/const.py:4958
 msgid "the gulf"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4950
+#: src/lifesim_lib/const.py:4959
 msgid "a gully"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4951
+#: src/lifesim_lib/const.py:4960
 msgid "a dry gully"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4952
+#: src/lifesim_lib/const.py:4961
 msgid "a hill"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4953
+#: src/lifesim_lib/const.py:4962
 msgid "the hills"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4954
+#: src/lifesim_lib/const.py:4963
 msgid "an iceberg"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4955
+#: src/lifesim_lib/const.py:4964
 msgid "an ice sheet"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4956
+#: src/lifesim_lib/const.py:4965
 msgid "an inselberg"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4957
+#: src/lifesim_lib/const.py:4966
 msgid "an island"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4958
+#: src/lifesim_lib/const.py:4967
 msgid "the islands"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4959
+#: src/lifesim_lib/const.py:4968
 msgid "an isthmus"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4960
+#: src/lifesim_lib/const.py:4969
 msgid "a jungle"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4961
+#: src/lifesim_lib/const.py:4970
 msgid "the jungle"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4962
+#: src/lifesim_lib/const.py:4971
 msgid "a lagoon"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4963
+#: src/lifesim_lib/const.py:4972
 msgid "a moraine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4964
+#: src/lifesim_lib/const.py:4973
 msgid "a mountain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4965
+#: src/lifesim_lib/const.py:4974
 msgid "the mountains"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4966
+#: src/lifesim_lib/const.py:4975
 msgid "the base of a mountain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4967
+#: src/lifesim_lib/const.py:4976
 msgid "the foot of a mountain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4968
+#: src/lifesim_lib/const.py:4977
 msgid "a mountain peak"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4969
+#: src/lifesim_lib/const.py:4978
 msgid "a mountain range"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4970
+#: src/lifesim_lib/const.py:4979
 msgid "the mountain range"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4971
+#: src/lifesim_lib/const.py:4980
 msgid "the top of a mountain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4972
+#: src/lifesim_lib/const.py:4981
 msgid "a fjord"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4973
+#: src/lifesim_lib/const.py:4982
 msgid "a forest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4974
+#: src/lifesim_lib/const.py:4983
 msgid "the forest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4975
+#: src/lifesim_lib/const.py:4984
 msgid "a deciduous forest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4976
+#: src/lifesim_lib/const.py:4985
 msgid "a temperate forest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4977
+#: src/lifesim_lib/const.py:4986
 msgid "a lake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4978
+#: src/lifesim_lib/const.py:4987
 msgid "the lake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4979
+#: src/lifesim_lib/const.py:4988
 msgid "the edge of a lake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4980
+#: src/lifesim_lib/const.py:4989
 msgid "a salt lake"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4981
+#: src/lifesim_lib/const.py:4990
 msgid "the salt lakes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4982
+#: src/lifesim_lib/const.py:4991
 msgid "a marsh"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4983
+#: src/lifesim_lib/const.py:4992
 msgid "the marshes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4984
+#: src/lifesim_lib/const.py:4993
 msgid "a mesa"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4985
+#: src/lifesim_lib/const.py:4994
 msgid "the mouth of the river"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4986
+#: src/lifesim_lib/const.py:4995
 msgid "an oasis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4987
+#: src/lifesim_lib/const.py:4996
 msgid "the ocean"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4988
+#: src/lifesim_lib/const.py:4997
 msgid "a salt pan"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4989
+#: src/lifesim_lib/const.py:4998
 msgid "a peninsula"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4990
+#: src/lifesim_lib/const.py:4999
 msgid "the peninsula"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4991
+#: src/lifesim_lib/const.py:5000
 msgid "a plain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4992
+#: src/lifesim_lib/const.py:5001
 msgid "the plains"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4993
+#: src/lifesim_lib/const.py:5002
 msgid "a flood plain"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4994
+#: src/lifesim_lib/const.py:5003
 msgid "the flood plains"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4995
+#: src/lifesim_lib/const.py:5004
 msgid "a pediment"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4996
+#: src/lifesim_lib/const.py:5005
 msgid "the plateau"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4998
+#: src/lifesim_lib/const.py:5007
 msgid "a prairie"
 msgstr ""
 
-#: src/lifesim_lib/const.py:4999
+#: src/lifesim_lib/const.py:5008
 msgid "the quays"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5000
+#: src/lifesim_lib/const.py:5009
 msgid "a rainforest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5001
+#: src/lifesim_lib/const.py:5010
 msgid "a subtropical rainforest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5002
+#: src/lifesim_lib/const.py:5011
 msgid "a tropical rainforest"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5003
+#: src/lifesim_lib/const.py:5012
 msgid "a ravine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5004
+#: src/lifesim_lib/const.py:5013
 msgid "the ravine"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5005
+#: src/lifesim_lib/const.py:5014
 msgid "a reef"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5006
+#: src/lifesim_lib/const.py:5015
 msgid "a coral reef"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5007
+#: src/lifesim_lib/const.py:5016
 msgid "the coral reef"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5009
+#: src/lifesim_lib/const.py:5018
 msgid "the river"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5010
+#: src/lifesim_lib/const.py:5019
 msgid "a river basin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5011
+#: src/lifesim_lib/const.py:5020
 msgid "the river basin"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5012
+#: src/lifesim_lib/const.py:5021
 msgid "a river delta"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5013
+#: src/lifesim_lib/const.py:5022
 msgid "the river delta"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5014
+#: src/lifesim_lib/const.py:5023
 msgid "the source of a river"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5015
+#: src/lifesim_lib/const.py:5024
 msgid "a savanna"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5016
+#: src/lifesim_lib/const.py:5025
 msgid "the sea"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5017
+#: src/lifesim_lib/const.py:5026
 msgid "the seaside"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5018
+#: src/lifesim_lib/const.py:5027
 msgid "the shrublands"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5019
+#: src/lifesim_lib/const.py:5028
 msgid "the sound"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5020
+#: src/lifesim_lib/const.py:5029
 msgid "a coastal sound"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5021
+#: src/lifesim_lib/const.py:5030
 msgid "a steppe"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5022
+#: src/lifesim_lib/const.py:5031
 msgid "the steppes"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5023
+#: src/lifesim_lib/const.py:5032
 msgid "a strait"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5025
+#: src/lifesim_lib/const.py:5034
 msgid "a swamp"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5026
+#: src/lifesim_lib/const.py:5035
 msgid "the swamp"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5027
+#: src/lifesim_lib/const.py:5036
 msgid "a tributary"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5028
+#: src/lifesim_lib/const.py:5037
 msgid "a tundra"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5029
+#: src/lifesim_lib/const.py:5038
 msgid "the tundra"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5030
+#: src/lifesim_lib/const.py:5039
 msgid "a valley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5031
+#: src/lifesim_lib/const.py:5040
 msgid "a river valley"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5032
+#: src/lifesim_lib/const.py:5041
 msgid "a volcano"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5033
+#: src/lifesim_lib/const.py:5042
 msgid "an active volcano"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5034
+#: src/lifesim_lib/const.py:5043
 msgid "a dormant volcano"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5035
+#: src/lifesim_lib/const.py:5044
 msgid "an extinct volcano"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5036
+#: src/lifesim_lib/const.py:5045
 msgid "a wadi"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5037
+#: src/lifesim_lib/const.py:5046
 msgid "some wadis"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5038
+#: src/lifesim_lib/const.py:5047
 msgid "a waterfall"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5039
+#: src/lifesim_lib/const.py:5048
 msgid "the waterfalls"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5040
+#: src/lifesim_lib/const.py:5049
 msgid "a wetland"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5041
+#: src/lifesim_lib/const.py:5050
 msgid "the wetlands"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5042
+#: src/lifesim_lib/const.py:5051
 msgid "some yardangs"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5043
+#: src/lifesim_lib/const.py:5052
 msgid "some zeugens"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5049
+#: src/lifesim_lib/const.py:5058
 msgid "a hot night"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5050
+#: src/lifesim_lib/const.py:5059
 msgid "a cold night"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5051
+#: src/lifesim_lib/const.py:5060
 msgid "a dark and stormy night"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5052
+#: src/lifesim_lib/const.py:5061
 msgid "a windy night"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5053
+#: src/lifesim_lib/const.py:5062
 msgid "a clear and starry night"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5054
+#: src/lifesim_lib/const.py:5063
 msgid "a hot sunny day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5055
+#: src/lifesim_lib/const.py:5064
 msgid "a hot day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5056
+#: src/lifesim_lib/const.py:5065
 msgid "a cold day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5057
+#: src/lifesim_lib/const.py:5066
 msgid "a wet and windy day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5058
+#: src/lifesim_lib/const.py:5067
 msgid "a windy day"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5059
+#: src/lifesim_lib/const.py:5068
 msgid "a cool, overcast evening"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5060
+#: src/lifesim_lib/const.py:5069
 msgid "a wet windy evening"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5061
+#: src/lifesim_lib/const.py:5070
 msgid "a hot sweaty evening"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5062
+#: src/lifesim_lib/const.py:5071
 msgid "a brisk early morning"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5063
+#: src/lifesim_lib/const.py:5072
 msgid "a warm overcast morning"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5071
+#: src/lifesim_lib/const.py:5080
 msgid "arm"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5072
+#: src/lifesim_lib/const.py:5081
 msgid "head"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5073
+#: src/lifesim_lib/const.py:5082
 msgid "leg"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5074
+#: src/lifesim_lib/const.py:5083
 msgid "foot"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5075
+#: src/lifesim_lib/const.py:5084
 msgid "knee"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5082
+#: src/lifesim_lib/const.py:5091
 msgid "punched"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5083
+#: src/lifesim_lib/const.py:5092
 msgid "hit"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5084
+#: src/lifesim_lib/const.py:5093
 msgid "kicked"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5085
+#: src/lifesim_lib/const.py:5094
 msgid "attacked"
 msgstr ""
 
-#: src/lifesim_lib/const.py:5086
+#: src/lifesim_lib/const.py:5095
 msgid "bit"
 msgstr ""
 
@@ -14513,36 +14522,70 @@ msgstr ""
 msgid "You tend to neglect your appearance, decreasing your Looks over time."
 msgstr ""
 
+#: src/lifesim_lib/lifesim_lib.py:218
+msgid "Thanatophobia"
+msgstr ""
+
 #: src/lifesim_lib/lifesim_lib.py:219
+msgid "You are afraid of death. You often worry about your own death or the death of a relative, and you lose more Happiness when a relative dies."
+msgstr ""
+
+#: src/lifesim_lib/lifesim_lib.py:224
 msgid "Moody"
 msgstr ""
 
-#: src/lifesim_lib/lifesim_lib.py:220
+#: src/lifesim_lib/lifesim_lib.py:225
 msgid "Your mood can change more easily. All changes to your Happiness are more intense."
 msgstr ""
 
-#: src/lifesim_lib/lifesim_lib.py:227
+#: src/lifesim_lib/lifesim_lib.py:232
 msgid "Non-Emotional"
 msgstr ""
 
-#: src/lifesim_lib/lifesim_lib.py:228
+#: src/lifesim_lib/lifesim_lib.py:233
 msgid "You don't react much to situations. Any changes to your Happiness are less intense."
 msgstr ""
 
-#: src/lifesim_lib/lifesim_lib.py:287 src/lifesim_lib/lifesim_lib.py:292
-#: src/lifesim_lib/lifesim_lib.py:303 src/lifesim_lib/lifesim_lib.py:308
+#: src/lifesim_lib/lifesim_lib.py:240
+msgid "Fitness-Enthusiast"
+msgstr ""
+
+#: src/lifesim_lib/lifesim_lib.py:241
+msgid "You really enjoy getting your blood pumping. Any changes to your Health are slightly more intense."
+msgstr ""
+
+#: src/lifesim_lib/lifesim_lib.py:247
+msgid "Gym_Junkie"
+msgstr ""
+
+#: src/lifesim_lib/lifesim_lib.py:248
+msgid "You love hitting the gym and pumping iron. Any changes to your Health are more intense."
+msgstr ""
+
+#: src/lifesim_lib/lifesim_lib.py:254
+msgid "Born_Athlete"
+msgstr ""
+
+#: src/lifesim_lib/lifesim_lib.py:255
+msgid "You love exercise and sport in all its forms. Any changes to your Health are significantly more intense."
+msgstr ""
+
+#: src/lifesim_lib/lifesim_lib.py:313 src/lifesim_lib/lifesim_lib.py:320
+#: src/lifesim_lib/lifesim_lib.py:333 src/lifesim_lib/lifesim_lib.py:340
 msgid "Invalid input; try again."
 msgstr ""
 
-#: src/lifesim_lib/lifesim_lib.py:322 src/people/classes/player.py:1045
+#: src/lifesim_lib/lifesim_lib.py:359 src/menus/main.py:809
+#: src/menus/main.py:819 src/people/classes/player.py:1426
 msgid "No"
 msgstr ""
 
-#: src/lifesim_lib/lifesim_lib.py:322 src/people/classes/player.py:1045
+#: src/lifesim_lib/lifesim_lib.py:359 src/menus/main.py:809
+#: src/menus/main.py:819 src/people/classes/player.py:1426
 msgid "Yes"
 msgstr ""
 
-#: src/lifesim_lib/lifesim_lib.py:337
+#: src/lifesim_lib/lifesim_lib.py:374
 msgid "Press Enter to continue..."
 msgstr ""
 
@@ -14550,1750 +14593,2714 @@ msgstr ""
 msgid "Activities Menu"
 msgstr ""
 
-#: src/menus/activities.py:14 src/menus/activities.py:35
-#: src/menus/activities.py:538 src/menus/activities.py:548
-#: src/menus/activities.py:635 src/menus/activities.py:785
-#: src/menus/main.py:49 src/menus/main.py:74 src/menus/main.py:505
-#: src/menus/main.py:547 src/menus/main.py:563 src/menus/main.py:616
-#: src/menus/main.py:674 src/menus/main.py:733 src/menus/main.py:739
+#: src/menus/activities.py:14 src/menus/activities.py:44
+#: src/menus/activities.py:655 src/menus/activities.py:665
+#: src/menus/activities.py:755 src/menus/activities.py:908
+#: src/menus/main.py:109 src/menus/main.py:134 src/menus/main.py:576
+#: src/menus/main.py:1129 src/menus/main.py:1145 src/menus/main.py:1198
+#: src/menus/main.py:1221 src/menus/main.py:1263 src/menus/main.py:1322
+#: src/menus/main.py:1328
 msgid "Back"
 msgstr ""
 
-#: src/menus/activities.py:16 src/menus/activities.py:37
+#: src/menus/activities.py:16 src/menus/activities.py:46
 msgid "Play with your toys"
 msgstr ""
 
-#: src/menus/activities.py:18 src/menus/activities.py:443
-msgid "Doctor"
+#: src/menus/activities.py:18 src/menus/activities.py:313
+msgid "Storytime"
 msgstr ""
 
-#: src/menus/activities.py:20 src/menus/activities.py:295
+#: src/menus/activities.py:19 src/menus/activities.py:326
+msgid "Music Time"
+msgstr ""
+
+#: src/menus/activities.py:21 src/menus/activities.py:339
 msgid "Arts and Crafts"
 msgstr ""
 
-#: src/menus/activities.py:22 src/menus/activities.py:535
-#: src/menus/activities.py:536
+#: src/menus/activities.py:23 src/menus/activities.py:442
+msgid "Early socialization"
+msgstr ""
+
+#: src/menus/activities.py:24 src/menus/activities.py:455
+msgid "Everyday learning"
+msgstr ""
+
+#: src/menus/activities.py:25 src/menus/activities.py:468
+msgid "Curiosity and exploration"
+msgstr ""
+
+#: src/menus/activities.py:27 src/menus/activities.py:531
+msgid "Doctor"
+msgstr ""
+
+#: src/menus/activities.py:29 src/menus/activities.py:623
+msgid "Witch Doctor"
+msgstr ""
+
+#: src/menus/activities.py:31 src/menus/activities.py:652
+#: src/menus/activities.py:653
 msgid "Mind & Body"
 msgstr ""
 
-#: src/menus/activities.py:24 src/menus/activities.py:394
+#: src/menus/activities.py:33 src/menus/activities.py:482
 msgid "Listen to music"
 msgstr ""
 
-#: src/menus/activities.py:27 src/menus/activities.py:737
+#: src/menus/activities.py:36 src/menus/activities.py:860
 msgid "Adoption"
 msgstr ""
 
-#: src/menus/activities.py:28 src/menus/activities.py:778
+#: src/menus/activities.py:37 src/menus/activities.py:901
 msgid "Lottery"
 msgstr ""
 
-#: src/menus/activities.py:29 src/menus/activities.py:691
+#: src/menus/activities.py:38 src/menus/activities.py:814
 msgid "Plastic Surgery"
 msgstr ""
 
-#: src/menus/activities.py:31 src/menus/activities.py:414
+#: src/menus/activities.py:40 src/menus/activities.py:502
 msgid "Find a Partner"
 msgstr ""
 
-#: src/menus/activities.py:32 src/menus/activities.py:860
+#: src/menus/activities.py:41 src/menus/activities.py:983
 msgid "Surrender"
 msgstr ""
 
-#: src/menus/activities.py:40
+#: src/menus/activities.py:49
 msgid "You don't feel like playing, but you decide to try anyway."
 msgstr ""
 
-#: src/menus/activities.py:55 src/menus/activities.py:102
+#: src/menus/activities.py:64 src/menus/activities.py:115
 msgid "You played with your toy wagon."
 msgstr ""
 
-#: src/menus/activities.py:56 src/menus/activities.py:103
-#: src/menus/activities.py:167 src/menus/activities.py:224
+#: src/menus/activities.py:65 src/menus/activities.py:116
+#: src/menus/activities.py:185 src/menus/activities.py:242
 msgid "You played with some of your balls."
 msgstr ""
 
-#: src/menus/activities.py:57
+#: src/menus/activities.py:66
 msgid "You raced around on your foot propelled bike."
 msgstr ""
 
-#: src/menus/activities.py:58 src/menus/activities.py:104
+#: src/menus/activities.py:67 src/menus/activities.py:117
 msgid "You played with your push-pull toy."
 msgstr ""
 
-#: src/menus/activities.py:59 src/menus/activities.py:105
+#: src/menus/activities.py:68 src/menus/activities.py:118
 msgid "You put toys in your wagon and pulled them around the living room."
 msgstr ""
 
-#: src/menus/activities.py:62 src/menus/activities.py:108
+#: src/menus/activities.py:71 src/menus/activities.py:121
 msgid "You swung on your toddler swing."
 msgstr ""
 
-#: src/menus/activities.py:63 src/menus/activities.py:109
+#: src/menus/activities.py:72 src/menus/activities.py:122
 msgid "You slid on your toddler slide."
 msgstr ""
 
-#: src/menus/activities.py:64 src/menus/activities.py:110
+#: src/menus/activities.py:73 src/menus/activities.py:123
 msgid "You played with your stacking toys."
 msgstr ""
 
-#: src/menus/activities.py:65 src/menus/activities.py:111
+#: src/menus/activities.py:74 src/menus/activities.py:124
 msgid "You played with your nesting toys."
 msgstr ""
 
-#: src/menus/activities.py:66 src/menus/activities.py:112
+#: src/menus/activities.py:75 src/menus/activities.py:125
 msgid "You played with your shape sorter."
 msgstr ""
 
-#: src/menus/activities.py:67 src/menus/activities.py:113
+#: src/menus/activities.py:76 src/menus/activities.py:126
 msgid "You played with your pop-up toys."
 msgstr ""
 
-#: src/menus/activities.py:68 src/menus/activities.py:114
+#: src/menus/activities.py:77 src/menus/activities.py:127
 msgid "You played with your puzzle with knobs."
 msgstr ""
 
-#: src/menus/activities.py:69 src/menus/activities.py:115
+#: src/menus/activities.py:78 src/menus/activities.py:128
 msgid "You played with your blocks."
 msgstr ""
 
-#: src/menus/activities.py:70 src/menus/activities.py:116
+#: src/menus/activities.py:79
+msgid "You stacked blocks into a tall tower and watched it tumble."
+msgstr ""
+
+#: src/menus/activities.py:80
+msgid "You molded animals out of clay."
+msgstr ""
+
+#: src/menus/activities.py:81
+msgid "You banged on a toy drum and made up a rhythm."
+msgstr ""
+
+#: src/menus/activities.py:82
+msgid "You explored the garden and collected leaves and rocks."
+msgstr ""
+
+#: src/menus/activities.py:83 src/menus/activities.py:134
 msgid "You played in your sandbox."
 msgstr ""
 
-#: src/menus/activities.py:71 src/menus/activities.py:117
+#: src/menus/activities.py:84 src/menus/activities.py:135
 msgid "You played with your sandbox toys."
 msgstr ""
 
-#: src/menus/activities.py:72 src/menus/activities.py:118
+#: src/menus/activities.py:85 src/menus/activities.py:136
 msgid "You played in your wading pool."
 msgstr ""
 
-#: src/menus/activities.py:73 src/menus/activities.py:119
+#: src/menus/activities.py:86 src/menus/activities.py:137
 msgid "You played with your wading pool toys"
 msgstr ""
 
-#: src/menus/activities.py:74 src/menus/activities.py:120
+#: src/menus/activities.py:87 src/menus/activities.py:138
 msgid "You played with your bath toys."
 msgstr ""
 
-#: src/menus/activities.py:75 src/menus/activities.py:121
+#: src/menus/activities.py:88 src/menus/activities.py:139
 msgid "Your mum gave you a bath and you played with your bath toys."
 msgstr ""
 
-#: src/menus/activities.py:78 src/menus/activities.py:124
+#: src/menus/activities.py:91 src/menus/activities.py:142
 msgid "Your dad gave you a bath and you played with your bath toys."
 msgstr ""
 
-#: src/menus/activities.py:81 src/menus/activities.py:127
-#: src/menus/activities.py:169 src/menus/activities.py:226
+#: src/menus/activities.py:94 src/menus/activities.py:145
+#: src/menus/activities.py:187 src/menus/activities.py:244
 msgid "You played with your stuffed animals."
 msgstr ""
 
-#: src/menus/activities.py:82 src/menus/activities.py:128
-#: src/menus/activities.py:170 src/menus/activities.py:227
+#: src/menus/activities.py:95 src/menus/activities.py:146
+#: src/menus/activities.py:188 src/menus/activities.py:245
 msgid "You played with your dolls."
 msgstr ""
 
-#: src/menus/activities.py:83 src/menus/activities.py:129
+#: src/menus/activities.py:96 src/menus/activities.py:147
 msgid "You played with your play vehicles."
 msgstr ""
 
-#: src/menus/activities.py:84 src/menus/activities.py:130
+#: src/menus/activities.py:97 src/menus/activities.py:148
 msgid "You played with your toy kitchen equipment."
 msgstr ""
 
-#: src/menus/activities.py:85 src/menus/activities.py:131
+#: src/menus/activities.py:98 src/menus/activities.py:149
 msgid "You played with your toy kitchen gadgets."
 msgstr ""
 
-#: src/menus/activities.py:86 src/menus/activities.py:132
+#: src/menus/activities.py:99 src/menus/activities.py:150
 msgid "You played with your toy telephone."
 msgstr ""
 
-#: src/menus/activities.py:87 src/menus/activities.py:133
+#: src/menus/activities.py:100 src/menus/activities.py:151
 msgid "You played with your toy lawn mower."
 msgstr ""
 
-#: src/menus/activities.py:88 src/menus/activities.py:134
+#: src/menus/activities.py:101 src/menus/activities.py:152
 msgid "You played with your toy shopping cart."
 msgstr ""
 
-#: src/menus/activities.py:89 src/menus/activities.py:135
+#: src/menus/activities.py:102 src/menus/activities.py:153
 msgid "You played with your toy workbench."
 msgstr ""
 
-#: src/menus/activities.py:90 src/menus/activities.py:136
+#: src/menus/activities.py:103 src/menus/activities.py:154
 msgid "You played in your playhouse."
 msgstr ""
 
-#: src/menus/activities.py:91 src/menus/activities.py:137
+#: src/menus/activities.py:104 src/menus/activities.py:155
 msgid "You pretended to hold a meeting at your toy table and chairs with your stuffed animals."
 msgstr ""
 
-#: src/menus/activities.py:94
+#: src/menus/activities.py:107
 msgid "You made a sausage out of clay."
 msgstr ""
 
-#: src/menus/activities.py:95
+#: src/menus/activities.py:108
 msgid "You made a a ball out of clay."
 msgstr ""
 
-#: src/menus/activities.py:96 src/menus/activities.py:142
+#: src/menus/activities.py:109 src/menus/activities.py:160
 msgid "You played with your playdough."
 msgstr ""
 
-#: src/menus/activities.py:97 src/menus/activities.py:143
+#: src/menus/activities.py:110 src/menus/activities.py:161
 msgid "You played with your toy guitar."
 msgstr ""
 
-#: src/menus/activities.py:98 src/menus/activities.py:144
+#: src/menus/activities.py:111 src/menus/activities.py:162
 msgid "You played with your toy piano."
 msgstr ""
 
-#: src/menus/activities.py:140
+#: src/menus/activities.py:129
+msgid "You built a castle out of blocks."
+msgstr ""
+
+#: src/menus/activities.py:130
+msgid "You sculpted animals out of clay."
+msgstr ""
+
+#: src/menus/activities.py:131
+msgid "You went on a bug hunt in the backyard."
+msgstr ""
+
+#: src/menus/activities.py:132
+msgid "You played a tune on a toy xylophone."
+msgstr ""
+
+#: src/menus/activities.py:133
+msgid "You walked through the park collecting leaves."
+msgstr ""
+
+#: src/menus/activities.py:158
 msgid "You made a rough pot of clay."
 msgstr ""
 
-#: src/menus/activities.py:141
+#: src/menus/activities.py:159
 msgid "You made a rough bowl out of clay."
 msgstr ""
 
-#: src/menus/activities.py:145 src/menus/activities.py:172
-#: src/menus/activities.py:229
+#: src/menus/activities.py:163 src/menus/activities.py:190
+#: src/menus/activities.py:247
 msgid "You kicked a ball in your yard."
 msgstr ""
 
-#: src/menus/activities.py:146 src/menus/activities.py:173
+#: src/menus/activities.py:164 src/menus/activities.py:191
 msgid "You fed your baby doll."
 msgstr ""
 
-#: src/menus/activities.py:147 src/menus/activities.py:174
+#: src/menus/activities.py:165 src/menus/activities.py:192
 msgid "You changed the daiper on your baby doll."
 msgstr ""
 
-#: src/menus/activities.py:148 src/menus/activities.py:175
+#: src/menus/activities.py:166 src/menus/activities.py:193
 msgid "You bathed your baby doll."
 msgstr ""
 
-#: src/menus/activities.py:149 src/menus/activities.py:176
+#: src/menus/activities.py:167 src/menus/activities.py:194
 msgid "You put your mum's clothes on and dressed up as her."
 msgstr ""
 
-#: src/menus/activities.py:150 src/menus/activities.py:177
+#: src/menus/activities.py:168 src/menus/activities.py:195
 msgid "You put your dad's clothes on and dressed up as him."
 msgstr ""
 
-#: src/menus/activities.py:151 src/menus/activities.py:178
+#: src/menus/activities.py:169 src/menus/activities.py:196
 msgid "You climbed on your climbing gym."
 msgstr ""
 
-#: src/menus/activities.py:152 src/menus/activities.py:179
+#: src/menus/activities.py:170 src/menus/activities.py:197
 msgid "You dressed up your stuffed animals."
 msgstr ""
 
-#: src/menus/activities.py:153 src/menus/activities.py:180
+#: src/menus/activities.py:171 src/menus/activities.py:198
 msgid "You changed your doll's clothes."
 msgstr ""
 
-#: src/menus/activities.py:154
+#: src/menus/activities.py:172
 msgid "You played with your chalk."
 msgstr ""
 
-#: src/menus/activities.py:155 src/menus/activities.py:182
+#: src/menus/activities.py:173 src/menus/activities.py:200
 msgid "You rode your tricycle."
 msgstr ""
 
-#: src/menus/activities.py:156 src/menus/activities.py:183
-#: src/menus/activities.py:232
+#: src/menus/activities.py:174 src/menus/activities.py:201
+#: src/menus/activities.py:250
 msgid "You read a storybook."
 msgstr ""
 
-#: src/menus/activities.py:157 src/menus/activities.py:184
-#: src/menus/activities.py:233
+#: src/menus/activities.py:175 src/menus/activities.py:202
+#: src/menus/activities.py:251
 msgid "You played with your finger puppets."
 msgstr ""
 
-#: src/menus/activities.py:158 src/menus/activities.py:185
-#: src/menus/activities.py:234
+#: src/menus/activities.py:176 src/menus/activities.py:203
+#: src/menus/activities.py:252
 msgid "You played with your hand puppet."
 msgstr ""
 
-#: src/menus/activities.py:159
+#: src/menus/activities.py:177
 msgid "You played a simple board game."
 msgstr ""
 
-#: src/menus/activities.py:160
+#: src/menus/activities.py:178
 msgid "You played a word matching game."
 msgstr ""
 
-#: src/menus/activities.py:161
+#: src/menus/activities.py:179
 msgid "You played a picture matching game."
 msgstr ""
 
-#: src/menus/activities.py:162
+#: src/menus/activities.py:180
 msgid "You played make believe with a cardboard box."
 msgstr ""
 
-#: src/menus/activities.py:163 src/menus/activities.py:190
+#: src/menus/activities.py:181 src/menus/activities.py:208
 msgid "You made a fort using bed sheets and cushions."
 msgstr ""
 
-#: src/menus/activities.py:168 src/menus/activities.py:225
+#: src/menus/activities.py:186 src/menus/activities.py:243
 msgid "You played with your Lego."
 msgstr ""
 
-#: src/menus/activities.py:171 src/menus/activities.py:228
+#: src/menus/activities.py:189 src/menus/activities.py:246
 msgid "You played with your toy cars."
 msgstr ""
 
-#: src/menus/activities.py:181 src/menus/activities.py:231
+#: src/menus/activities.py:199 src/menus/activities.py:249
 msgid "You played with your chalk and drew on the sidewalk."
 msgstr ""
 
-#: src/menus/activities.py:186 src/menus/activities.py:235
+#: src/menus/activities.py:204 src/menus/activities.py:253
 msgid "You played a board game."
 msgstr ""
 
-#: src/menus/activities.py:187 src/menus/activities.py:236
+#: src/menus/activities.py:205 src/menus/activities.py:254
 msgid "You played a word game."
 msgstr ""
 
-#: src/menus/activities.py:188 src/menus/activities.py:237
+#: src/menus/activities.py:206 src/menus/activities.py:255
 msgid "You played a video game."
 msgstr ""
 
-#: src/menus/activities.py:189
+#: src/menus/activities.py:207
 msgid "You made a costume out of a cardboard box."
 msgstr ""
 
-#: src/menus/activities.py:191 src/menus/activities.py:241
+#: src/menus/activities.py:209 src/menus/activities.py:259
 msgid "You rode your bicycle."
 msgstr ""
 
-#: src/menus/activities.py:192 src/menus/activities.py:242
+#: src/menus/activities.py:210 src/menus/activities.py:260
 msgid "You played with some gym equipment."
 msgstr ""
 
-#: src/menus/activities.py:193
+#: src/menus/activities.py:211
 msgid "You played with your baseball glove."
 msgstr ""
 
-#: src/menus/activities.py:194
+#: src/menus/activities.py:212
 msgid "You played with your hockey stick."
 msgstr ""
 
-#: src/menus/activities.py:195
+#: src/menus/activities.py:213
 msgid "You played with your tennis racquet."
 msgstr ""
 
-#: src/menus/activities.py:196 src/menus/activities.py:246
+#: src/menus/activities.py:214 src/menus/activities.py:264
 msgid "You played tennis with your family."
 msgstr ""
 
-#: src/menus/activities.py:197 src/menus/activities.py:248
+#: src/menus/activities.py:215 src/menus/activities.py:266
 msgid "You played football with your friends."
 msgstr ""
 
-#: src/menus/activities.py:198 src/menus/activities.py:249
+#: src/menus/activities.py:216 src/menus/activities.py:267
 msgid "You walked on your stilts."
 msgstr ""
 
-#: src/menus/activities.py:199 src/menus/activities.py:250
+#: src/menus/activities.py:217 src/menus/activities.py:268
 msgid "You skated on your ice skates."
 msgstr ""
 
-#: src/menus/activities.py:200 src/menus/activities.py:252
+#: src/menus/activities.py:218 src/menus/activities.py:270
 msgid "You skated on your roller blades."
 msgstr ""
 
-#: src/menus/activities.py:201 src/menus/activities.py:254
+#: src/menus/activities.py:219 src/menus/activities.py:272
 msgid "You skated on your skateboard."
 msgstr ""
 
-#: src/menus/activities.py:202 src/menus/activities.py:256
+#: src/menus/activities.py:220 src/menus/activities.py:274
 msgid "You rode your scooter."
 msgstr ""
 
-#: src/menus/activities.py:203 src/menus/activities.py:257
+#: src/menus/activities.py:221 src/menus/activities.py:275
 msgid "You rode your pogo stick."
 msgstr ""
 
-#: src/menus/activities.py:204 src/menus/activities.py:258
+#: src/menus/activities.py:222 src/menus/activities.py:276
 msgid "You played with your jump rope."
 msgstr ""
 
-#: src/menus/activities.py:205 src/menus/activities.py:264
+#: src/menus/activities.py:223 src/menus/activities.py:282
 msgid "You made a paper aeroplane."
 msgstr ""
 
-#: src/menus/activities.py:206 src/menus/activities.py:265
+#: src/menus/activities.py:224 src/menus/activities.py:283
 msgid "You played with your action figures."
 msgstr ""
 
-#: src/menus/activities.py:207 src/menus/activities.py:266
+#: src/menus/activities.py:225 src/menus/activities.py:284
 msgid "You played with your train set."
 msgstr ""
 
-#: src/menus/activities.py:208 src/menus/activities.py:267
+#: src/menus/activities.py:226 src/menus/activities.py:285
 msgid "You played with your magic set."
 msgstr ""
 
-#: src/menus/activities.py:209 src/menus/activities.py:268
+#: src/menus/activities.py:227 src/menus/activities.py:286
 msgid "You played with your craft kit."
 msgstr ""
 
-#: src/menus/activities.py:210 src/menus/activities.py:269
+#: src/menus/activities.py:228 src/menus/activities.py:287
 msgid "You played with your science set."
 msgstr ""
 
-#: src/menus/activities.py:211
+#: src/menus/activities.py:229
 msgid "You painted a basic picture."
 msgstr ""
 
-#: src/menus/activities.py:212 src/menus/activities.py:271
+#: src/menus/activities.py:230 src/menus/activities.py:289
 msgid "You played tabletop sports."
 msgstr ""
 
-#: src/menus/activities.py:213
+#: src/menus/activities.py:231
 msgid "You played with a jigsaw puzzle."
 msgstr ""
 
-#: src/menus/activities.py:214 src/menus/activities.py:273
+#: src/menus/activities.py:232 src/menus/activities.py:291
 msgid "You played with your fashion dolls."
 msgstr ""
 
-#: src/menus/activities.py:215 src/menus/activities.py:274
+#: src/menus/activities.py:233 src/menus/activities.py:292
 msgid "You played with your career dolls."
 msgstr ""
 
-#: src/menus/activities.py:216
+#: src/menus/activities.py:234
 msgid "You played with your dollhouse."
 msgstr ""
 
-#: src/menus/activities.py:217 src/menus/activities.py:275
+#: src/menus/activities.py:235 src/menus/activities.py:293
 msgid "You played with your puppets."
 msgstr ""
 
-#: src/menus/activities.py:218 src/menus/activities.py:276
+#: src/menus/activities.py:236 src/menus/activities.py:294
 msgid "You played with your toy theatre."
 msgstr ""
 
-#: src/menus/activities.py:219 src/menus/activities.py:277
+#: src/menus/activities.py:237 src/menus/activities.py:295
 msgid "You played with your marionettes."
 msgstr ""
 
-#: src/menus/activities.py:220
+#: src/menus/activities.py:238
 msgid "You read a fairytale and imagined you were in it."
 msgstr ""
 
-#: src/menus/activities.py:230
+#: src/menus/activities.py:248
 msgid "You dressed up your stuffed toys."
 msgstr ""
 
-#: src/menus/activities.py:238
+#: src/menus/activities.py:256
 msgid "You made a fort using bed sheets and cushions, and slept in it."
 msgstr ""
 
-#: src/menus/activities.py:243
+#: src/menus/activities.py:261
 msgid "You played baseball with your friends."
 msgstr ""
 
-#: src/menus/activities.py:244
+#: src/menus/activities.py:262
 msgid "You played hockey with your friends."
 msgstr ""
 
-#: src/menus/activities.py:245
+#: src/menus/activities.py:263
 msgid "You played tennis with your friends."
 msgstr ""
 
-#: src/menus/activities.py:247
+#: src/menus/activities.py:265
 msgid "You played with your football."
 msgstr ""
 
-#: src/menus/activities.py:251
+#: src/menus/activities.py:269
 msgid "You went ice skating with your friends."
 msgstr ""
 
-#: src/menus/activities.py:253
+#: src/menus/activities.py:271
 msgid "You went roller blading with your friends."
 msgstr ""
 
-#: src/menus/activities.py:255
+#: src/menus/activities.py:273
 msgid "You went skateboarding with your friends."
 msgstr ""
 
-#: src/menus/activities.py:259
+#: src/menus/activities.py:277
 msgid "You played jump rope with your friends."
 msgstr ""
 
-#: src/menus/activities.py:260
+#: src/menus/activities.py:278
 msgid "You played with your basketball."
 msgstr ""
 
-#: src/menus/activities.py:261
+#: src/menus/activities.py:279
 msgid "You played basketball with your friends."
 msgstr ""
 
-#: src/menus/activities.py:262
+#: src/menus/activities.py:280
 msgid "You played with your netball."
 msgstr ""
 
-#: src/menus/activities.py:263
+#: src/menus/activities.py:281
 msgid "You played netball with your friends."
 msgstr ""
 
-#: src/menus/activities.py:270
+#: src/menus/activities.py:288
 msgid "You painted a picture."
 msgstr ""
 
-#: src/menus/activities.py:272
+#: src/menus/activities.py:290
 msgid "You completed a jigsaw puzzle."
 msgstr ""
 
-#: src/menus/activities.py:278
+#: src/menus/activities.py:296
 msgid "You read a story and imagined you were in it."
 msgstr ""
 
-#: src/menus/activities.py:279
+#: src/menus/activities.py:297
 msgid "You played chess with a friend."
 msgstr ""
 
-#: src/menus/activities.py:280
+#: src/menus/activities.py:298
 msgid "You played foosball with a friend."
 msgstr ""
 
-#: src/menus/activities.py:281
+#: src/menus/activities.py:299
 msgid "You played darts with a friend."
 msgstr ""
 
-#: src/menus/activities.py:282
+#: src/menus/activities.py:300
 msgid "You played with your RC car."
 msgstr ""
 
-#: src/menus/activities.py:283
+#: src/menus/activities.py:301
 msgid "You played with your drone."
 msgstr ""
 
-#: src/menus/activities.py:284
+#: src/menus/activities.py:302
 msgid "You read a mystery book."
 msgstr ""
 
-#: src/menus/activities.py:285
+#: src/menus/activities.py:303
 msgid "You read an adventure book."
 msgstr ""
 
-#: src/menus/activities.py:286
+#: src/menus/activities.py:304
 msgid "You played checkers with a friend."
 msgstr ""
 
-#: src/menus/activities.py:287
+#: src/menus/activities.py:305
 msgid "You played solitaire with a pack of cards."
 msgstr ""
 
-#: src/menus/activities.py:288
+#: src/menus/activities.py:306
 msgid "You played dominoes with some friends."
 msgstr ""
 
-#: src/menus/activities.py:289
+#: src/menus/activities.py:307
 msgid "You made a robot with Meccano"
 msgstr ""
 
-#: src/menus/activities.py:299
-msgid "You thought about doing arts and crafts, but couldn't decide what to make."
-msgstr ""
-
-#: src/menus/activities.py:302
-msgid "For some reason, you couldn't think of any ideas."
-msgstr ""
-
-#: src/menus/activities.py:303
-msgid "You came up with a cool arts and crafts idea, only to quickly forget what it was."
-msgstr ""
-
-#: src/menus/activities.py:306
-msgid "You were unable to think of anything creative to do."
-msgstr ""
-
-#: src/menus/activities.py:307
-msgid "You felt a bit frustrated when you couldn't come up with any creative ideas."
-msgstr ""
-
-#: src/menus/activities.py:316 src/menus/activities.py:326
-#: src/menus/activities.py:338 src/menus/activities.py:352
-#: src/menus/activities.py:371
-msgid "You decided to finger-paint."
+#: src/menus/activities.py:316
+msgid "Your parent read aloud a picture book and asked you questions about it."
 msgstr ""
 
 #: src/menus/activities.py:317
-msgid "You decided to make something from mud!"
+msgid "You looked at the pictures and told the story back in your own words."
 msgstr ""
 
 #: src/menus/activities.py:318
-msgid "You drew in your colouring book"
+msgid "You created a simple storybook with drawings."
 msgstr ""
 
 #: src/menus/activities.py:319
-msgid "You squished clay between your fingers."
-msgstr ""
-
-#: src/menus/activities.py:320
-msgid "You drew with your large crayons."
-msgstr ""
-
-#: src/menus/activities.py:324 src/menus/activities.py:336
-#: src/menus/activities.py:350 src/menus/activities.py:369
-msgid "You decided to draw."
-msgstr ""
-
-#: src/menus/activities.py:325 src/menus/activities.py:337
-#: src/menus/activities.py:351 src/menus/activities.py:370
-msgid "You decided to make something from clay!"
-msgstr ""
-
-#: src/menus/activities.py:327
-msgid "You played with your crayons."
-msgstr ""
-
-#: src/menus/activities.py:328 src/menus/activities.py:340
-#: src/menus/activities.py:354
-msgid "You drew in your colouring book."
+msgid "You made up a story about animals you saw outside."
 msgstr ""
 
 #: src/menus/activities.py:329
-msgid "You drew a house that looked like a triangle on top of a square."
+msgid "You shook a tambourine and sang a song."
+msgstr ""
+
+#: src/menus/activities.py:330
+msgid "You banged on a small drum and explored rhythm."
+msgstr ""
+
+#: src/menus/activities.py:331
+msgid "You danced around while playing a toy xylophone."
 msgstr ""
 
 #: src/menus/activities.py:332
-msgid "You drew a stick figure picture of your family."
-msgstr ""
-
-#: src/menus/activities.py:339 src/menus/activities.py:353
-msgid "You drew with your crayons."
-msgstr ""
-
-#: src/menus/activities.py:341
-msgid "You tried to draw a picture of your house."
-msgstr ""
-
-#: src/menus/activities.py:342
-msgid "You tried to draw a picture of your family."
+msgid "You clapped to the beat of a song with your family."
 msgstr ""
 
 #: src/menus/activities.py:343
-msgid "You tried to draw a picture of a landscape."
-msgstr ""
-
-#: src/menus/activities.py:344
-msgid "You tried to draw a picture of a cat."
-msgstr ""
-
-#: src/menus/activities.py:345
-msgid "You tried to draw a picture of a bowl of fruit."
+msgid "You thought about doing arts and crafts, but couldn't decide what to make."
 msgstr ""
 
 #: src/menus/activities.py:346
-msgid "You tried to draw your favourite cartoon character."
+msgid "For some reason, you couldn't think of any ideas."
 msgstr ""
 
-#: src/menus/activities.py:355 src/menus/activities.py:373
-msgid "You drew a picture of your house."
+#: src/menus/activities.py:347
+msgid "You came up with a cool arts and crafts idea, only to quickly forget what it was."
 msgstr ""
 
-#: src/menus/activities.py:356 src/menus/activities.py:374
-msgid "You drew a picture of your family."
+#: src/menus/activities.py:350
+msgid "You were unable to think of anything creative to do."
 msgstr ""
 
-#: src/menus/activities.py:357 src/menus/activities.py:375
-msgid "You drew a picture of a landscape."
+#: src/menus/activities.py:351
+msgid "You felt a bit frustrated when you couldn't come up with any creative ideas."
 msgstr ""
 
-#: src/menus/activities.py:358 src/menus/activities.py:376
-msgid "You drew a picture of a cat."
-msgstr ""
-
-#: src/menus/activities.py:359 src/menus/activities.py:377
-msgid "You drew a picture of a bowl of fruit."
-msgstr ""
-
-#: src/menus/activities.py:360 src/menus/activities.py:378
-msgid "You drew your favourite cartoon character."
+#: src/menus/activities.py:360 src/menus/activities.py:372
+#: src/menus/activities.py:386 src/menus/activities.py:400
+#: src/menus/activities.py:419
+msgid "You decided to finger-paint."
 msgstr ""
 
 #: src/menus/activities.py:361
-msgid "You tried to paint a picture of your house."
+msgid "You decided to make something from mud!"
 msgstr ""
 
 #: src/menus/activities.py:362
-msgid "You tried to paint a picture of your family."
+msgid "You drew in your colouring book"
 msgstr ""
 
 #: src/menus/activities.py:363
-msgid "You tried to paint a picture of a landscape."
+msgid "You squished clay between your fingers."
 msgstr ""
 
 #: src/menus/activities.py:364
-msgid "You tried to paint a picture of a cat."
+msgid "You drew with your large crayons."
 msgstr ""
 
 #: src/menus/activities.py:365
-msgid "You tried to paint a picture of a bowl of fruit."
+msgid "You mixed colours together with your fingers."
 msgstr ""
 
-#: src/menus/activities.py:372
-msgid "You drew with charcoal."
+#: src/menus/activities.py:366
+msgid "You glued leaves onto paper to feel their textures."
+msgstr ""
+
+#: src/menus/activities.py:370 src/menus/activities.py:384
+#: src/menus/activities.py:398 src/menus/activities.py:417
+msgid "You decided to draw."
+msgstr ""
+
+#: src/menus/activities.py:371 src/menus/activities.py:385
+#: src/menus/activities.py:399 src/menus/activities.py:418
+msgid "You decided to make something from clay!"
+msgstr ""
+
+#: src/menus/activities.py:373
+msgid "You played with your crayons."
+msgstr ""
+
+#: src/menus/activities.py:374 src/menus/activities.py:388
+#: src/menus/activities.py:402
+msgid "You drew in your colouring book."
+msgstr ""
+
+#: src/menus/activities.py:375
+msgid "You drew a house that looked like a triangle on top of a square."
+msgstr ""
+
+#: src/menus/activities.py:378
+msgid "You drew a stick figure picture of your family."
 msgstr ""
 
 #: src/menus/activities.py:379
-msgid "You painted a picture of your house."
+msgid "You mixed different paints to see what colours you could make."
 msgstr ""
 
 #: src/menus/activities.py:380
+msgid "You glued fabric and paper together to explore textures."
+msgstr ""
+
+#: src/menus/activities.py:387 src/menus/activities.py:401
+msgid "You drew with your crayons."
+msgstr ""
+
+#: src/menus/activities.py:389
+msgid "You tried to draw a picture of your house."
+msgstr ""
+
+#: src/menus/activities.py:390
+msgid "You tried to draw a picture of your family."
+msgstr ""
+
+#: src/menus/activities.py:391
+msgid "You tried to draw a picture of a landscape."
+msgstr ""
+
+#: src/menus/activities.py:392
+msgid "You tried to draw a picture of a cat."
+msgstr ""
+
+#: src/menus/activities.py:393
+msgid "You tried to draw a picture of a bowl of fruit."
+msgstr ""
+
+#: src/menus/activities.py:394
+msgid "You tried to draw your favourite cartoon character."
+msgstr ""
+
+#: src/menus/activities.py:403 src/menus/activities.py:421
+msgid "You drew a picture of your house."
+msgstr ""
+
+#: src/menus/activities.py:404 src/menus/activities.py:422
+msgid "You drew a picture of your family."
+msgstr ""
+
+#: src/menus/activities.py:405 src/menus/activities.py:423
+msgid "You drew a picture of a landscape."
+msgstr ""
+
+#: src/menus/activities.py:406 src/menus/activities.py:424
+msgid "You drew a picture of a cat."
+msgstr ""
+
+#: src/menus/activities.py:407 src/menus/activities.py:425
+msgid "You drew a picture of a bowl of fruit."
+msgstr ""
+
+#: src/menus/activities.py:408 src/menus/activities.py:426
+msgid "You drew your favourite cartoon character."
+msgstr ""
+
+#: src/menus/activities.py:409
+msgid "You tried to paint a picture of your house."
+msgstr ""
+
+#: src/menus/activities.py:410
+msgid "You tried to paint a picture of your family."
+msgstr ""
+
+#: src/menus/activities.py:411
+msgid "You tried to paint a picture of a landscape."
+msgstr ""
+
+#: src/menus/activities.py:412
+msgid "You tried to paint a picture of a cat."
+msgstr ""
+
+#: src/menus/activities.py:413
+msgid "You tried to paint a picture of a bowl of fruit."
+msgstr ""
+
+#: src/menus/activities.py:420
+msgid "You drew with charcoal."
+msgstr ""
+
+#: src/menus/activities.py:427
+msgid "You painted a picture of your house."
+msgstr ""
+
+#: src/menus/activities.py:428
 msgid "You painted a picture of your family."
 msgstr ""
 
-#: src/menus/activities.py:381
+#: src/menus/activities.py:429
 msgid "You painted a picture of a landscape."
 msgstr ""
 
-#: src/menus/activities.py:382
+#: src/menus/activities.py:430
 msgid "You painted a picture of a cat."
 msgstr ""
 
-#: src/menus/activities.py:383
+#: src/menus/activities.py:431
 msgid "You painted a picture of a bowl of fruit."
 msgstr ""
 
-#: src/menus/activities.py:396
-msgid "hip-hop"
+#: src/menus/activities.py:445
+msgid "You met with other kids for a playdate and practiced sharing."
 msgstr ""
 
-#: src/menus/activities.py:396
-msgid "latin music"
+#: src/menus/activities.py:446
+msgid "You joined a parent-child class at the library."
 msgstr ""
 
-#: src/menus/activities.py:396
-msgid "pop music"
-msgstr ""
-
-#: src/menus/activities.py:396
-msgid "rock music"
-msgstr ""
-
-#: src/menus/activities.py:398
-msgid "You listened to some music."
-msgstr ""
-
-#: src/menus/activities.py:401
-msgid "You listened to some {music_type}."
-msgstr ""
-
-#: src/menus/activities.py:402
-msgid "You played your favorite song."
-msgstr ""
-
-#: src/menus/activities.py:403
-msgid "You listened to a song by {music_artist}."
-msgstr ""
-
-#: src/menus/activities.py:417
-msgid "You are unable to find anyone to ask on a date."
-msgstr ""
-
-#: src/menus/activities.py:420
-msgid "a female"
-msgstr ""
-
-#: src/menus/activities.py:420
-msgid "a male"
-msgstr ""
-
-#: src/menus/activities.py:422
-msgid "You met {a_male_female} named {name}."
-msgstr ""
-
-#: src/menus/activities.py:430
-msgid "Ask {him_her} out"
-msgstr ""
-
-#: src/menus/activities.py:431
-msgid "No, {hes_shes} not my type"
-msgstr ""
-
-#: src/menus/activities.py:435 src/people/classes/player.py:1033
-msgid "You are now dating {name}."
-msgstr ""
-
-#: src/menus/activities.py:440
-msgid "{name} rejected you."
+#: src/menus/activities.py:447
+msgid "You visited a toddler gym and made new friends."
 msgstr ""
 
 #: src/menus/activities.py:448
-msgid "Would you like to visit the doctor? ($100 consultation fee)"
+msgid "You played a collaborative game that taught patience and empathy."
 msgstr ""
 
-#: src/menus/activities.py:451
-msgid "Would you like to visit the doctor?"
+#: src/menus/activities.py:458
+msgid "You helped cook dinner and learned new words."
 msgstr ""
 
-#: src/menus/activities.py:454
-msgid "You don't have enough money."
+#: src/menus/activities.py:459
+msgid "You watered the garden and talked about how plants grow."
 msgstr ""
 
 #: src/menus/activities.py:460
-msgid "The doctor has determined that you are not suffering from any illnesses."
+msgid "You helped shop for groceries and named the colours of fruits."
 msgstr ""
 
-#: src/menus/activities.py:466
-msgid "The doctor has determined that you are currently suffering from the following:"
+#: src/menus/activities.py:461
+msgid "You visited a museum and picked up new vocabulary."
 msgstr ""
 
-#: src/menus/activities.py:477
-msgid "Treat {illness}"
+#: src/menus/activities.py:471
+msgid "You sorted your toys by color and counted them."
 msgstr ""
 
-#: src/menus/activities.py:512
-msgid "You were treated for your {illness}."
+#: src/menus/activities.py:472
+msgid "You mixed different colours together to see what would happen."
+msgstr ""
+
+#: src/menus/activities.py:473
+msgid "You planted a seed and watched it begin to sprout."
+msgstr ""
+
+#: src/menus/activities.py:474
+msgid "You asked a big question and heard a simple answer."
+msgstr ""
+
+#: src/menus/activities.py:484
+msgid "hip-hop"
+msgstr ""
+
+#: src/menus/activities.py:484
+msgid "latin music"
+msgstr ""
+
+#: src/menus/activities.py:484
+msgid "pop music"
+msgstr ""
+
+#: src/menus/activities.py:484
+msgid "rock music"
+msgstr ""
+
+#: src/menus/activities.py:486
+msgid "You listened to some music."
+msgstr ""
+
+#: src/menus/activities.py:489
+msgid "You listened to some {music_type}."
+msgstr ""
+
+#: src/menus/activities.py:490
+msgid "You played your favorite song."
+msgstr ""
+
+#: src/menus/activities.py:491
+msgid "You listened to a song by {music_artist}."
+msgstr ""
+
+#: src/menus/activities.py:505
+msgid "You are unable to find anyone to ask on a date."
+msgstr ""
+
+#: src/menus/activities.py:508
+msgid "a female"
+msgstr ""
+
+#: src/menus/activities.py:508
+msgid "a male"
+msgstr ""
+
+#: src/menus/activities.py:510
+msgid "You met {a_male_female} named {name}."
 msgstr ""
 
 #: src/menus/activities.py:518
-msgid "the {n}"
+msgid "Ask {him_her} out"
 msgstr ""
 
-#: src/menus/activities.py:522
-msgid "You are no longer suffering from {illness}."
+#: src/menus/activities.py:519
+msgid "No, {hes_shes} not my type"
 msgstr ""
 
-#: src/menus/activities.py:531
-msgid "You continue to suffer from {illness}."
+#: src/menus/activities.py:523 src/people/classes/player.py:1405
+msgid "You are now dating {name}."
 msgstr ""
 
-#: src/menus/activities.py:541 src/menus/activities.py:550
-msgid "Meditate"
+#: src/menus/activities.py:528
+msgid "{name} rejected you."
 msgstr ""
 
-#: src/menus/activities.py:542 src/menus/activities.py:573
-msgid "Gym"
+#: src/menus/activities.py:536
+msgid "Would you like to visit the doctor? ($100 consultation fee)"
 msgstr ""
 
-#: src/menus/activities.py:543 src/menus/activities.py:591
-msgid "Library"
+#: src/menus/activities.py:539
+msgid "Would you like to visit the doctor?"
 msgstr ""
 
-#: src/menus/activities.py:545 src/menus/activities.py:626
-msgid "Read a Book"
+#: src/menus/activities.py:542 src/menus/activities.py:634
+msgid "You don't have enough money."
 msgstr ""
 
-#: src/menus/activities.py:551
-msgid "You practiced meditation."
+#: src/menus/activities.py:548
+msgid "The doctor has determined that you are not suffering from any illnesses."
+msgstr ""
+
+#: src/menus/activities.py:554
+msgid "The doctor has determined that you are currently suffering from the following:"
 msgstr ""
 
 #: src/menus/activities.py:565
+msgid "Treat {illness}"
+msgstr ""
+
+#: src/menus/activities.py:600
+msgid "You were treated for your {illness}."
+msgstr ""
+
+#: src/menus/activities.py:606
+msgid "the {n}"
+msgstr ""
+
+#: src/menus/activities.py:610 src/menus/activities.py:644
+msgid "You are no longer suffering from {illness}."
+msgstr ""
+
+#: src/menus/activities.py:619
+msgid "You continue to suffer from {illness}."
+msgstr ""
+
+#: src/menus/activities.py:632
+msgid ""
+"The witch doctor gives you a treatment they claim is \"special.\"\n"
+"Do you take it? Cost: {fee}"
+msgstr ""
+
+#: src/menus/activities.py:638
+msgid "You took the witch doctor's treatments."
+msgstr ""
+
+#: src/menus/activities.py:650
+msgid "You died after taking a witch doctor's treatments."
+msgstr ""
+
+#: src/menus/activities.py:658 src/menus/activities.py:667
+msgid "Meditate"
+msgstr ""
+
+#: src/menus/activities.py:659 src/menus/activities.py:691
+msgid "Gym"
+msgstr ""
+
+#: src/menus/activities.py:660 src/menus/activities.py:710
+msgid "Library"
+msgstr ""
+
+#: src/menus/activities.py:662 src/menus/activities.py:746
+msgid "Read a Book"
+msgstr ""
+
+#: src/menus/activities.py:668
+msgid "You practiced meditation."
+msgstr ""
+
+#: src/menus/activities.py:683
 msgid "You have achieved a deeper awareness of yourself."
 msgstr ""
 
-#: src/menus/activities.py:566 src/menus/main.py:556
-#: src/people/classes/player.py:656
+#: src/menus/activities.py:684 src/menus/main.py:1138
+#: src/people/classes/player.py:851
 msgid "Karma"
 msgstr ""
 
-#: src/menus/activities.py:575
+#: src/menus/activities.py:693
 msgid "Your health is too weak to visit the gym."
 msgstr ""
 
-#: src/menus/activities.py:580
+#: src/menus/activities.py:698
 msgid "You worked out at the gym."
 msgstr ""
 
-#: src/menus/activities.py:581 src/menus/activities.py:604
-#: src/menus/activities.py:669 src/menus/main.py:115
+#: src/menus/activities.py:699 src/menus/activities.py:723
+#: src/menus/activities.py:789 src/menus/main.py:175
 msgid "Your Enjoyment"
 msgstr ""
 
-#: src/menus/activities.py:592
+#: src/menus/activities.py:711
 msgid "You went to the library."
 msgstr ""
 
-#: src/menus/activities.py:634
+#: src/menus/activities.py:754
 msgid "Which book would you like to read?"
 msgstr ""
 
-#: src/menus/activities.py:652
+#: src/menus/activities.py:772
 msgid "You are reading \"{book_title}\""
 msgstr ""
 
-#: src/menus/activities.py:653
+#: src/menus/activities.py:773
 msgid "Category"
 msgstr ""
 
-#: src/menus/activities.py:654
+#: src/menus/activities.py:774
 msgid "Pages read"
 msgstr ""
 
-#: src/menus/activities.py:656
+#: src/menus/activities.py:776
 msgid "Press 1 to read each page"
 msgstr ""
 
-#: src/menus/activities.py:657
+#: src/menus/activities.py:777
 msgid "Abandon it"
 msgstr ""
 
-#: src/menus/activities.py:657
+#: src/menus/activities.py:777
 msgid "Pick a different book"
 msgstr ""
 
-#: src/menus/activities.py:657
+#: src/menus/activities.py:777
 msgid "Read page"
 msgstr ""
 
-#: src/menus/activities.py:662
+#: src/menus/activities.py:782
 msgid "You read all {pages} pages of \"{book}\"."
 msgstr ""
 
-#: src/menus/activities.py:694
+#: src/menus/activities.py:817
 msgid "Please wait a while before getting another plastic surgery."
 msgstr ""
 
-#: src/menus/activities.py:695
+#: src/menus/activities.py:818
 msgid "Would you like to receive plastic surgery? (Cost: $25000)"
 msgstr ""
 
-#: src/menus/activities.py:697 src/menus/activities.py:766
-#: src/menus/activities.py:794
+#: src/menus/activities.py:820 src/menus/activities.py:889
+#: src/menus/activities.py:917
 msgid "You don't have enough money"
 msgstr ""
 
-#: src/menus/activities.py:701
+#: src/menus/activities.py:824
 msgid "Which plastic surgeon would you like to visit?"
 msgstr ""
 
-#: src/menus/activities.py:702
+#: src/menus/activities.py:825
 msgid "Dr. {name}"
 msgstr ""
 
-#: src/menus/activities.py:703
+#: src/menus/activities.py:826
 msgid "Reputation: {bar}"
 msgstr ""
 
-#: src/menus/activities.py:711
+#: src/menus/activities.py:834
 msgid "Your plastic surgery was botched by {name}!"
 msgstr ""
 
-#: src/menus/activities.py:712
+#: src/menus/activities.py:835
 msgid "Damage"
 msgstr ""
 
-#: src/menus/activities.py:718
+#: src/menus/activities.py:841
 msgid "You died after receiving a botched plastic surgery."
 msgstr ""
 
-#: src/menus/activities.py:722
+#: src/menus/activities.py:845
 msgid "Your plastic surgery was successful."
 msgstr ""
 
-#: src/menus/activities.py:723
+#: src/menus/activities.py:846
 msgid "Results"
 msgstr ""
 
-#: src/menus/activities.py:740
+#: src/menus/activities.py:863
 msgid "You are too old to adopt a child."
 msgstr ""
 
-#: src/menus/activities.py:742
+#: src/menus/activities.py:865
 msgid "You already have enough children."
 msgstr ""
 
-#: src/menus/activities.py:753
+#: src/menus/activities.py:876
 msgid "a {age}-year-old boy"
 msgstr ""
 
-#: src/menus/activities.py:755
+#: src/menus/activities.py:878
 msgid "a {age}-year-old girl"
 msgstr ""
 
-#: src/menus/activities.py:757
+#: src/menus/activities.py:880
 msgid "You have an opportunity to adopt {name}, {name_and_age}."
 msgstr ""
 
-#: src/menus/activities.py:759 src/menus/main.py:67 src/menus/main.py:554
-#: src/people/classes/player.py:530 src/people/classes/player.py:692
+#: src/menus/activities.py:882 src/menus/main.py:127 src/menus/main.py:1136
+#: src/people/classes/player.py:706 src/people/classes/player.py:887
 msgid "Smarts"
 msgstr ""
 
-#: src/menus/activities.py:760 src/menus/main.py:68 src/menus/main.py:555
-#: src/people/classes/player.py:531 src/people/classes/player.py:693
+#: src/menus/activities.py:883 src/menus/main.py:128 src/menus/main.py:1137
+#: src/people/classes/player.py:707 src/people/classes/player.py:888
 msgid "Looks"
 msgstr ""
 
-#: src/menus/activities.py:763
+#: src/menus/activities.py:886
 msgid "Cost"
 msgstr ""
 
-#: src/menus/activities.py:764
+#: src/menus/activities.py:887
 msgid "Would you like to adopt this child?"
 msgstr ""
 
-#: src/menus/activities.py:770
+#: src/menus/activities.py:893
 msgid "Would you like to change {name}'s last name to match yours?"
 msgstr ""
 
-#: src/menus/activities.py:773
+#: src/menus/activities.py:896
 msgid "You have adopted {name}, {name_and_age}."
 msgstr ""
 
-#: src/menus/activities.py:780
+#: src/menus/activities.py:903
 msgid "Play the lottery today!"
 msgstr ""
 
-#: src/menus/activities.py:781
+#: src/menus/activities.py:904
 msgid "Ticket cost: $4 each"
 msgstr ""
 
-#: src/menus/activities.py:783
+#: src/menus/activities.py:906
 msgid "Lottery jackpot: ${jackpot}"
 msgstr ""
 
-#: src/menus/activities.py:785
+#: src/menus/activities.py:908
 msgid "Buy 10 tickets"
 msgstr ""
 
-#: src/menus/activities.py:785
+#: src/menus/activities.py:908
 msgid "Buy a ticket"
 msgstr ""
 
-#: src/menus/activities.py:798
+#: src/menus/activities.py:921
 msgid "Guess the 4 winning numbers between 1 and 20. Each number in the line must be separated by a space."
 msgstr ""
 
-#: src/menus/activities.py:803
+#: src/menus/activities.py:926
 msgid "The numbers within each line must be unique."
 msgstr ""
 
-#: src/menus/activities.py:805
+#: src/menus/activities.py:928
 msgid "The numbers must be unique."
 msgstr ""
 
-#: src/menus/activities.py:812
+#: src/menus/activities.py:935
 msgid "Guess #{num}: "
 msgstr ""
 
-#: src/menus/activities.py:814
+#: src/menus/activities.py:937
 msgid "Guess: "
 msgstr ""
 
-#: src/menus/activities.py:820
+#: src/menus/activities.py:943
 msgid "The values must all be integers."
 msgstr ""
 
-#: src/menus/activities.py:824
+#: src/menus/activities.py:947
 msgid "You must enter exactly 4 numbers"
 msgstr ""
 
-#: src/menus/activities.py:827
+#: src/menus/activities.py:950
 msgid "All values must be between 1 and 20"
 msgstr ""
 
-#: src/menus/activities.py:830
+#: src/menus/activities.py:953
 msgid "All values must be unique."
 msgstr ""
 
-#: src/menus/activities.py:836
+#: src/menus/activities.py:959
 msgid "The winning numbers are {nums}"
 msgstr ""
 
-#: src/menus/activities.py:847
+#: src/menus/activities.py:970
 msgid "YOU WON THE ${amount} LOTTERY JACKPOT!!!"
 msgstr ""
 
-#: src/menus/activities.py:856
+#: src/menus/activities.py:979
 msgid "You did not win the ${amount} lottery jackpot."
 msgstr ""
 
-#: src/menus/activities.py:862
+#: src/menus/activities.py:985
 msgid "Are you sure you want to surrender this life?"
 msgstr ""
 
-#: src/menus/activities.py:863
+#: src/menus/activities.py:986
 msgid "This will kill your current character. Continue?"
 msgstr ""
 
-#: src/menus/activities.py:864
+#: src/menus/activities.py:987
 msgid "You surrendered."
 msgstr ""
 
-#: src/menus/main.py:17
-msgid "Your name"
-msgstr ""
-
-#: src/menus/main.py:19
-msgid "Traits"
-msgstr ""
-
-#: src/menus/main.py:20 src/menus/main.py:614
-msgid "Gender"
-msgstr ""
-
-#: src/menus/main.py:21 src/menus/main.py:65
-msgid "Money"
-msgstr ""
-
-#: src/menus/main.py:23
-msgid "Salary"
-msgstr ""
-
-#: src/menus/main.py:25
-msgid "Generation"
-msgstr ""
-
-#: src/menus/main.py:28 src/menus/main.py:41
-msgid "Age +1"
-msgstr ""
-
-#: src/menus/main.py:28 src/menus/main.py:44
-msgid "Relationships"
-msgstr ""
-
-#: src/menus/main.py:28 src/menus/main.py:499
-msgid "Activities"
-msgstr ""
-
-#: src/menus/main.py:30 src/menus/main.py:501
-msgid "School"
-msgstr ""
-
-#: src/menus/main.py:33 src/menus/main.py:665
-msgid "Job Menu"
-msgstr ""
-
-#: src/menus/main.py:35 src/menus/main.py:636
-msgid "Find a Job"
-msgstr ""
-
-#: src/menus/main.py:36 src/menus/main.py:726
-msgid "View Saved Games"
-msgstr ""
-
-#: src/menus/main.py:38 src/menus/main.py:546
-msgid "Debug Menu"
-msgstr ""
-
-#: src/menus/main.py:46
-msgid "Relationships: "
-msgstr ""
-
 #: src/menus/main.py:56
-msgid "Name"
+msgid "study extra"
 msgstr ""
 
-#: src/menus/main.py:61
-msgid "Age"
+#: src/menus/main.py:57
+msgid "do chores"
+msgstr ""
+
+#: src/menus/main.py:58
+msgid "improve your behavior"
 msgstr ""
 
 #: src/menus/main.py:62
-msgid "Relationship"
+msgid "complete an extra credit assignment"
+msgstr ""
+
+#: src/menus/main.py:63
+msgid "stay after class to help"
 msgstr ""
 
 #: src/menus/main.py:64
-msgid "Generosity"
+msgid "behave better in class"
 msgstr ""
 
 #: src/menus/main.py:70
-msgid "Petulance"
+msgid "Your name"
 msgstr ""
 
 #: src/menus/main.py:72
-msgid "Craziness"
+msgid "Traits"
 msgstr ""
 
-#: src/menus/main.py:77 src/menus/main.py:99
-msgid "Spend time"
+#: src/menus/main.py:73 src/menus/main.py:1196
+msgid "Gender"
 msgstr ""
 
-#: src/menus/main.py:79 src/menus/main.py:129
-msgid "Have a conversation"
+#: src/menus/main.py:74 src/menus/main.py:125
+msgid "Money"
 msgstr ""
 
-#: src/menus/main.py:81 src/menus/main.py:233
-msgid "Compliment"
+#: src/menus/main.py:76 src/menus/main.py:1255
+msgid "Job Title"
 msgstr ""
 
-#: src/menus/main.py:82 src/menus/main.py:299
-msgid "Insult"
+#: src/menus/main.py:77 src/menus/main.py:1256
+msgid "Salary"
 msgstr ""
 
-#: src/menus/main.py:84 src/menus/main.py:335
-msgid "Have a baby"
+#: src/menus/main.py:79
+msgid "Generation"
 msgstr ""
 
-#: src/menus/main.py:86 src/menus/main.py:401
-msgid "Break up"
+#: src/menus/main.py:82
+msgid "Current Goal"
 msgstr ""
 
-#: src/menus/main.py:88 src/menus/main.py:480
-msgid "Divorce"
+#: src/menus/main.py:85
+msgid "Progress"
 msgstr ""
 
-#: src/menus/main.py:89 src/menus/main.py:487
-msgid "Renew Vows"
+#: src/menus/main.py:88 src/menus/main.py:101
+msgid "Age +1"
 msgstr ""
 
-#: src/menus/main.py:91 src/menus/main.py:412
-msgid "Propose"
+#: src/menus/main.py:88 src/menus/main.py:104
+msgid "Relationships"
 msgstr ""
 
-#: src/menus/main.py:93 src/menus/main.py:445
-msgid "Plan the wedding"
+#: src/menus/main.py:88 src/menus/main.py:560
+msgid "Activities"
 msgstr ""
 
-#: src/menus/main.py:94 src/menus/main.py:433
-msgid "Call off the engagement"
+#: src/menus/main.py:90 src/menus/main.py:563
+msgid "School"
 msgstr ""
 
-#: src/menus/main.py:96 src/menus/main.py:213
-msgid "Ask for money"
+#: src/menus/main.py:93 src/menus/main.py:1252
+msgid "Job Menu"
 msgstr ""
 
-#: src/menus/main.py:101
-msgid "Your {relation} refused to see you."
+#: src/menus/main.py:95 src/menus/main.py:1218
+msgid "Find a Job"
 msgstr ""
 
-#: src/menus/main.py:113
-msgid "You took your {relation} {place}."
+#: src/menus/main.py:96 src/menus/main.py:1315
+msgid "View Saved Games"
 msgstr ""
 
-#: src/menus/main.py:117
-msgid "{his_her} Enjoyment"
+#: src/menus/main.py:98 src/menus/main.py:1128
+msgid "Debug Menu"
+msgstr ""
+
+#: src/menus/main.py:106
+msgid "Relationships: "
+msgstr ""
+
+#: src/menus/main.py:116
+msgid "Name"
+msgstr ""
+
+#: src/menus/main.py:121
+msgid "Age"
+msgstr ""
+
+#: src/menus/main.py:122
+msgid "Relationship"
+msgstr ""
+
+#: src/menus/main.py:124
+msgid "Generosity"
+msgstr ""
+
+#: src/menus/main.py:130
+msgid "Petulance"
 msgstr ""
 
 #: src/menus/main.py:132
-msgid "Your {relation} isn't interested in having a conversation with you."
+msgid "Craziness"
 msgstr ""
 
-#: src/menus/main.py:156
-msgid "You and your {relation} had a chat about {chat}."
+#: src/menus/main.py:137 src/menus/main.py:159
+msgid "Spend time"
 msgstr ""
 
-#: src/menus/main.py:160
-msgid "You and your {relation} discussed {discussion}."
+#: src/menus/main.py:139 src/menus/main.py:189
+msgid "Have a conversation"
 msgstr ""
 
-#: src/menus/main.py:164
-msgid "You and your {relation} talked about {talk}."
+#: src/menus/main.py:141 src/menus/main.py:293
+msgid "Compliment"
 msgstr ""
 
-#: src/menus/main.py:168
-msgid "You and your {relation} had a heart-to-heart about {heart_to_heart}."
+#: src/menus/main.py:142 src/menus/main.py:360
+msgid "Insult"
+msgstr ""
+
+#: src/menus/main.py:144 src/menus/main.py:396
+msgid "Have a baby"
+msgstr ""
+
+#: src/menus/main.py:146 src/menus/main.py:462
+msgid "Break up"
+msgstr ""
+
+#: src/menus/main.py:148 src/menus/main.py:541
+msgid "Divorce"
+msgstr ""
+
+#: src/menus/main.py:149 src/menus/main.py:548
+msgid "Renew Vows"
+msgstr ""
+
+#: src/menus/main.py:151 src/menus/main.py:473
+msgid "Propose"
+msgstr ""
+
+#: src/menus/main.py:153 src/menus/main.py:506
+msgid "Plan the wedding"
+msgstr ""
+
+#: src/menus/main.py:154 src/menus/main.py:494
+msgid "Call off the engagement"
+msgstr ""
+
+#: src/menus/main.py:156 src/menus/main.py:273
+msgid "Ask for money"
+msgstr ""
+
+#: src/menus/main.py:161
+msgid "Your {relation} refused to see you."
 msgstr ""
 
 #: src/menus/main.py:173
-msgid "Agreement"
+msgid "You took your {relation} {place}."
 msgstr ""
 
-#: src/menus/main.py:184
-msgid "You and your {relation} got into an argument. What will you do?"
+#: src/menus/main.py:177
+msgid "{his_her} Enjoyment"
 msgstr ""
 
-#: src/menus/main.py:189
-msgid "Apologize"
-msgstr ""
-
-#: src/menus/main.py:190
-msgid "Agree to disagree"
-msgstr ""
-
-#: src/menus/main.py:191
-msgid "Insult {him_her}"
-msgstr ""
-
-#: src/menus/main.py:197
-msgid "You apologized to your {relation}"
-msgstr ""
-
-#: src/menus/main.py:203
-msgid "You agreed to disagree"
-msgstr ""
-
-#: src/menus/main.py:208
-msgid "You called your {relation} {insult}."
+#: src/menus/main.py:192
+msgid "Your {relation} isn't interested in having a conversation with you."
 msgstr ""
 
 #: src/menus/main.py:216
-msgid "Your {parent} told you to stop asking for money."
+msgid "You and your {relation} had a chat about {chat}."
 msgstr ""
 
-#: src/menus/main.py:219
-msgid "{he_she} called you {insult}."
+#: src/menus/main.py:220
+msgid "You and your {relation} discussed {discussion}."
 msgstr ""
 
-#: src/menus/main.py:225
-msgid "Your {parent} gave you ${amount}."
+#: src/menus/main.py:224
+msgid "You and your {relation} talked about {talk}."
 msgstr ""
 
-#: src/menus/main.py:230
-msgid "Your {parent} refused to give you any money."
+#: src/menus/main.py:228
+msgid "You and your {relation} had a heart-to-heart about {heart_to_heart}."
+msgstr ""
+
+#: src/menus/main.py:233
+msgid "Agreement"
+msgstr ""
+
+#: src/menus/main.py:244
+msgid "You and your {relation} got into an argument. What will you do?"
+msgstr ""
+
+#: src/menus/main.py:249
+msgid "Apologize"
+msgstr ""
+
+#: src/menus/main.py:250
+msgid "Agree to disagree"
 msgstr ""
 
 #: src/menus/main.py:251
-msgid "an alpha male"
-msgstr ""
-
-#: src/menus/main.py:252
-msgid "handsome"
-msgstr ""
-
-#: src/menus/main.py:256
-msgid "an alpha female"
+msgid "Insult {him_her}"
 msgstr ""
 
 #: src/menus/main.py:257
-msgid "beautiful"
+msgid "You apologized to your {relation}"
 msgstr ""
 
-#: src/menus/main.py:261
-msgid "You told your {relation} that {hes_shes} {compliment}."
+#: src/menus/main.py:263
+msgid "You agreed to disagree"
 msgstr ""
 
 #: src/menus/main.py:268
+msgid "You called your {relation} {insult}."
+msgstr ""
+
+#: src/menus/main.py:276
+msgid "Your {parent} told you to stop asking for money."
+msgstr ""
+
+#: src/menus/main.py:279
+msgid "{he_she} called you {insult}."
+msgstr ""
+
+#: src/menus/main.py:285
+msgid "Your {parent} gave you ${amount}."
+msgstr ""
+
+#: src/menus/main.py:290
+msgid "Your {parent} refused to give you any money."
+msgstr ""
+
+#: src/menus/main.py:312
+msgid "an alpha male"
+msgstr ""
+
+#: src/menus/main.py:313
+msgid "handsome"
+msgstr ""
+
+#: src/menus/main.py:317
+msgid "an alpha female"
+msgstr ""
+
+#: src/menus/main.py:318
+msgid "beautiful"
+msgstr ""
+
+#: src/menus/main.py:322
+msgid "You told your {relation} that {hes_shes} {compliment}."
+msgstr ""
+
+#: src/menus/main.py:329
 msgid "{his_her} Appreciation"
 msgstr ""
 
-#: src/menus/main.py:284
+#: src/menus/main.py:345
 msgid "Your {relation} told you that you're {compliment}!"
 msgstr ""
 
-#: src/menus/main.py:302
+#: src/menus/main.py:363
 msgid "Are you sure you want to insult your {relation}?"
 msgstr ""
 
-#: src/menus/main.py:308
+#: src/menus/main.py:369
 msgid "You called your {rel} {insult}."
 msgstr ""
 
-#: src/menus/main.py:324
+#: src/menus/main.py:385
 msgid "Your {rel} attacked you!"
 msgstr ""
 
-#: src/menus/main.py:330
+#: src/menus/main.py:391
 msgid "Your {rel} called you {insult}!"
 msgstr ""
 
-#: src/menus/main.py:340
+#: src/menus/main.py:401
 msgid "Your {partner} is already pregnant!"
 msgstr ""
 
-#: src/menus/main.py:342
+#: src/menus/main.py:403
 msgid "You are already pregnant!"
 msgstr ""
 
-#: src/menus/main.py:345
+#: src/menus/main.py:406
 msgid "You and your {partner} tried for a baby."
 msgstr ""
 
-#: src/menus/main.py:349
+#: src/menus/main.py:410
 msgid "Your {partner} is pregnant with your baby!"
 msgstr ""
 
-#: src/menus/main.py:351
+#: src/menus/main.py:412
 msgid "You are pregnant with {name}'s baby!"
 msgstr ""
 
-#: src/menus/main.py:352
+#: src/menus/main.py:413
 msgid "What will you do"
 msgstr ""
 
-#: src/menus/main.py:354
+#: src/menus/main.py:415
 msgid "Keep the baby"
 msgstr ""
 
-#: src/menus/main.py:355
+#: src/menus/main.py:416
 msgid "Get an abortion"
 msgstr ""
 
-#: src/menus/main.py:368
+#: src/menus/main.py:429
 msgid "Your {partner} got an abortion anyway!"
 msgstr ""
 
-#: src/menus/main.py:370
+#: src/menus/main.py:431
 msgid "Your {partner} forced you to get an abortion!"
 msgstr ""
 
-#: src/menus/main.py:376
+#: src/menus/main.py:437
 msgid "Your {partner} refused to get an abortion!"
 msgstr ""
 
-#: src/menus/main.py:378
+#: src/menus/main.py:439
 msgid "Your {partner} forced you to keep the baby!"
 msgstr ""
 
-#: src/menus/main.py:384
+#: src/menus/main.py:445
 msgid "You made your {partner} get an abortion!"
 msgstr ""
 
-#: src/menus/main.py:386
+#: src/menus/main.py:447
 msgid "You got an abortion!"
 msgstr ""
 
-#: src/menus/main.py:396
+#: src/menus/main.py:457
 msgid "You failed to get pregnant."
 msgstr ""
 
-#: src/menus/main.py:396
+#: src/menus/main.py:457
 msgid "You failed to get your {partner} pregnant."
 msgstr ""
 
-#: src/menus/main.py:399
+#: src/menus/main.py:460
 msgid "Your {partner} doesn't want to have a baby with you."
 msgstr ""
 
-#: src/menus/main.py:404
+#: src/menus/main.py:465
 msgid "Are you sure you want to break up with your {partner}?"
 msgstr ""
 
-#: src/menus/main.py:409
+#: src/menus/main.py:470
 msgid "You broke up with your {partner}."
 msgstr ""
 
-#: src/menus/main.py:421
+#: src/menus/main.py:482
 msgid "Your {partner} accepted your proposal!"
 msgstr ""
 
-#: src/menus/main.py:427
+#: src/menus/main.py:488
 msgid "Your {partner} rejected your proposal."
 msgstr ""
 
-#: src/menus/main.py:436
+#: src/menus/main.py:497
 msgid "Are you sure you want to call off your engagement with your {partner}?"
 msgstr ""
 
-#: src/menus/main.py:441
+#: src/menus/main.py:502
 msgid "You called off your engagement with your {partner}."
 msgstr ""
 
-#: src/menus/main.py:447
-msgid "golf course"
-msgstr ""
-
-#: src/menus/main.py:448
-msgid "vineyard"
-msgstr ""
-
-#: src/menus/main.py:449
-msgid "family member's house"
-msgstr ""
-
-#: src/menus/main.py:450
-msgid "courthouse"
-msgstr ""
-
-#: src/menus/main.py:451
-msgid "restaurant"
-msgstr ""
-
-#: src/menus/main.py:452
-msgid "drive-thru wedding chapel"
-msgstr ""
-
-#: src/menus/main.py:453
-msgid "country club"
-msgstr ""
-
-#: src/menus/main.py:458
+#: src/menus/main.py:519
 msgid "Choose a location:"
 msgstr ""
 
-#: src/menus/main.py:463
+#: src/menus/main.py:524
 msgid ""
 "You have chosen to marry {name} at a {place}.\n"
 "Cost: ${price}"
 msgstr ""
 
-#: src/menus/main.py:464
+#: src/menus/main.py:525
 msgid "Actually, never mind"
 msgstr ""
 
-#: src/menus/main.py:464
+#: src/menus/main.py:525
 msgid "Do it"
 msgstr ""
 
-#: src/menus/main.py:464
+#: src/menus/main.py:525
 msgid "Edit the plan"
 msgstr ""
 
-#: src/menus/main.py:467
+#: src/menus/main.py:528
 msgid "You don't have enough money for this wedding plan."
 msgstr ""
 
-#: src/menus/main.py:470
+#: src/menus/main.py:531
 msgid "You married {name} at a {place}."
 msgstr ""
 
-#: src/menus/main.py:482
+#: src/menus/main.py:543
 msgid "Are you sure you want to divorce your {partner}?"
 msgstr ""
 
-#: src/menus/main.py:484
+#: src/menus/main.py:545
 msgid "You divorced your {partner}."
 msgstr ""
 
-#: src/menus/main.py:490
+#: src/menus/main.py:551
 msgid "Your {partner} doesn't want to renew your wedding vows."
 msgstr ""
 
-#: src/menus/main.py:494
+#: src/menus/main.py:555
 msgid "You and your {partner} renewed your wedding vows."
 msgstr ""
 
-#: src/menus/main.py:502
+#: src/menus/main.py:564
 msgid "School Menu"
 msgstr ""
 
-#: src/menus/main.py:504
+#: src/menus/main.py:566
 msgid "Grades"
 msgstr ""
 
-#: src/menus/main.py:505
-msgid "Drop out"
+#: src/menus/main.py:567
+msgid "Knowledge"
 msgstr ""
 
-#: src/menus/main.py:505
-msgid "Skip school"
+#: src/menus/main.py:568 src/people/classes/player.py:889
+msgid "Popularity"
 msgstr ""
 
-#: src/menus/main.py:505
+#: src/menus/main.py:569
+msgid "Parent Approval"
+msgstr ""
+
+#: src/menus/main.py:570
+msgid "Teacher Favor"
+msgstr ""
+
+#: src/menus/main.py:571
+msgid "Friends"
+msgstr ""
+
+#: src/menus/main.py:572
+msgid "Rivals"
+msgstr ""
+
+#: src/menus/main.py:573
+msgid "Romantic interests"
+msgstr ""
+
+#: src/menus/main.py:577
 msgid "Study harder"
 msgstr ""
 
-#: src/menus/main.py:508
+#: src/menus/main.py:578
+msgid "Drop out"
+msgstr ""
+
+#: src/menus/main.py:579
+msgid "Skip school"
+msgstr ""
+
+#: src/menus/main.py:580
+msgid "Hang out"
+msgstr ""
+
+#: src/menus/main.py:581
+msgid "Study together"
+msgstr ""
+
+#: src/menus/main.py:582
+msgid "Gossip"
+msgstr ""
+
+#: src/menus/main.py:584
+msgid "Parent meeting"
+msgstr ""
+
+#: src/menus/main.py:586
+msgid "Meet teacher"
+msgstr ""
+
+#: src/menus/main.py:590
+msgid "Attend party"
+msgstr ""
+
+#: src/menus/main.py:594
+msgid "Train sport"
+msgstr ""
+
+#: src/menus/main.py:597
+msgid "Ask a question in class"
+msgstr ""
+
+#: src/menus/main.py:597
+msgid "Help a classmate"
+msgstr ""
+
+#: src/menus/main.py:597
+msgid "Join a club"
+msgstr ""
+
+#: src/menus/main.py:597
+msgid "Join a sports team"
+msgstr ""
+
+#: src/menus/main.py:597
+msgid "Start a project"
+msgstr ""
+
+#: src/menus/main.py:599
+msgid "Choose elective"
+msgstr ""
+
+#: src/menus/main.py:599
+msgid "Deal with bullying"
+msgstr ""
+
+#: src/menus/main.py:599
+msgid "Join sports team"
+msgstr ""
+
+#: src/menus/main.py:599
+msgid "Set career aspiration"
+msgstr ""
+
+#: src/menus/main.py:599
+msgid "Student council"
+msgstr ""
+
+#: src/menus/main.py:599
+msgid "Study group"
+msgstr ""
+
+#: src/menus/main.py:601
+msgid "Advanced course options"
+msgstr ""
+
+#: src/menus/main.py:601
+msgid "College prep tests"
+msgstr ""
+
+#: src/menus/main.py:601
+msgid "Extracurricular leadership"
+msgstr ""
+
+#: src/menus/main.py:601
+msgid "Part-time job"
+msgstr ""
+
+#: src/menus/main.py:601
+msgid "Prom"
+msgstr ""
+
+#: src/menus/main.py:609
+msgid "You're too tired to train."
+msgstr ""
+
+#: src/menus/main.py:612
+msgid "You trained with the {sport} team."
+msgstr ""
+
+#: src/menus/main.py:623
+msgid "You're too tired to party."
+msgstr ""
+
+#: src/menus/main.py:625
+msgid "You attended a party."
+msgstr ""
+
+#: src/menus/main.py:636
 msgid "You began studying harder"
 msgstr ""
 
-#: src/menus/main.py:525
+#: src/menus/main.py:638
+msgid "You're too tired to study."
+msgstr ""
+
+#: src/menus/main.py:657
 msgid "You dropped out of school."
 msgstr ""
 
-#: src/menus/main.py:530
+#: src/menus/main.py:662
 msgid "Your parents won't let you drop out of school."
 msgstr ""
 
-#: src/menus/main.py:534
+#: src/menus/main.py:665
 msgid "You skipped school and went {place} instead."
 msgstr ""
 
-#: src/menus/main.py:538
+#: src/menus/main.py:669
 msgid ""
 "You were caught skipping school!\n"
 "You were sent to the principal's office and got detention."
 msgstr ""
 
-#: src/menus/main.py:547
-msgid "Identity"
-msgstr ""
-
-#: src/menus/main.py:547
-msgid "Stats"
-msgstr ""
-
-#: src/menus/main.py:551
-msgid "Your stats"
-msgstr ""
-
-#: src/menus/main.py:552 src/people/classes/player.py:690
-msgid "Happiness"
-msgstr ""
-
-#: src/menus/main.py:558
-msgid "The below stats only matter if you have a job:"
-msgstr ""
-
-#: src/menus/main.py:559 src/menus/main.py:669
-msgid "Stress"
-msgstr ""
-
-#: src/menus/main.py:560 src/menus/main.py:669
-msgid "Performance"
-msgstr ""
-
-#: src/menus/main.py:564
-msgid "Modify Happiness"
-msgstr ""
-
-#: src/menus/main.py:565
-msgid "Modify Health"
-msgstr ""
-
-#: src/menus/main.py:566
-msgid "Modify Smarts"
-msgstr ""
-
-#: src/menus/main.py:567
-msgid "Modify Looks"
-msgstr ""
-
-#: src/menus/main.py:568
-msgid "Modify Karma"
-msgstr ""
-
-#: src/menus/main.py:569
-msgid "Modify Stress"
-msgstr ""
-
-#: src/menus/main.py:570
-msgid "Modify Performance"
-msgstr ""
-
-#: src/menus/main.py:575
-msgid "What would you like to set Happiness to? (0-100)"
-msgstr ""
-
-#: src/menus/main.py:580
-msgid "What would you like to set Health to? (0-100)"
-msgstr ""
-
-#: src/menus/main.py:585
-msgid "What would you like to set Smarts to? (0-100)"
-msgstr ""
-
-#: src/menus/main.py:590
-msgid "What would you like to set Looks to? (0-100)"
-msgstr ""
-
-#: src/menus/main.py:595
-msgid "What would you like to set Karma to? (0-100)"
-msgstr ""
-
-#: src/menus/main.py:600
-msgid "What would you like to set Stress to? (0-100)"
-msgstr ""
-
-#: src/menus/main.py:605
-msgid "What would you like to set Performance to? (0-100)"
-msgstr ""
-
-#: src/menus/main.py:612
-msgid "First name"
-msgstr ""
-
-#: src/menus/main.py:613
-msgid "Last name"
-msgstr ""
-
-#: src/menus/main.py:617
-msgid "Change first name"
-msgstr ""
-
-#: src/menus/main.py:618
-msgid "Change last name"
-msgstr ""
-
-#: src/menus/main.py:619
-msgid "Change gender"
-msgstr ""
-
-#: src/menus/main.py:624
-msgid "Enter first name: "
-msgstr ""
-
-#: src/menus/main.py:628
-msgid "Enter last name: "
-msgstr ""
-
-#: src/menus/main.py:641
-msgid "You found a job with a salary of ${salary:,}. Would you like to apply?"
-msgstr ""
-
-#: src/menus/main.py:657
-msgid "You got the job!"
-msgstr ""
-
-#: src/menus/main.py:661
-msgid "You didn't get an interview."
-msgstr ""
-
-#: src/menus/main.py:666
-msgid "Your job"
-msgstr ""
-
-#: src/menus/main.py:671
-msgid "Hours"
-msgstr ""
-
-#: src/menus/main.py:675
-msgid "Work Harder"
-msgstr ""
-
-#: src/menus/main.py:676
-msgid "Quit Job"
-msgstr ""
-
-#: src/menus/main.py:676
-msgid "Retire"
-msgstr ""
-
-#: src/menus/main.py:677
-msgid "Adjust Hours"
-msgstr ""
-
 #: src/menus/main.py:678
-msgid "Request a Raise"
+msgid "You're too tired to hang out."
+msgstr ""
+
+#: src/menus/main.py:681
+msgid "You went to the movies with friends."
+msgstr ""
+
+#: src/menus/main.py:682
+msgid "You played video games at a friend's house."
+msgstr ""
+
+#: src/menus/main.py:683
+msgid "You hung out at the park."
+msgstr ""
+
+#: src/menus/main.py:684
+msgid "You spent the afternoon at the mall."
+msgstr ""
+
+#: src/menus/main.py:685
+msgid "You went to the movies with friends and laughed so hard popcorn flew everywhere."
+msgstr ""
+
+#: src/menus/main.py:686
+msgid "You played video games at a friend's house and pulled off an epic comeback win."
+msgstr ""
+
+#: src/menus/main.py:687
+msgid "You hung out at the park, chasing frisbees and dodging squirrels."
+msgstr ""
+
+#: src/menus/main.py:688
+msgid "You spent the afternoon at the mall, trying on ridiculous outfits and striking poses."
+msgstr ""
+
+#: src/menus/main.py:689
+msgid "You had a picnic in the backyard, complete with ant invasions and silly stories."
+msgstr ""
+
+#: src/menus/main.py:690
+msgid "You biked around the neighborhood, racing each other like pros."
+msgstr ""
+
+#: src/menus/main.py:691
+msgid "You built a massive blanket fort and declared it your new kingdom."
 msgstr ""
 
 #: src/menus/main.py:692
-msgid "Do you want to retire? You will receive a yearly pension of ${pension}"
+msgid "You tried baking cookies together, ending up with more dough on your faces than in the oven."
+msgstr ""
+
+#: src/menus/main.py:693
+msgid "You stargazed on the roof, making up constellations like 'The Giant Pizza'."
+msgstr ""
+
+#: src/menus/main.py:694
+msgid "You had a water balloon fight that turned the yard into a splash zone."
+msgstr ""
+
+#: src/menus/main.py:695
+msgid "You explored a local museum, pretending to be time travelers."
+msgstr ""
+
+#: src/menus/main.py:696
+msgid "You jammed out to music in the garage, forming a fake band called 'The Homework Rebels'."
+msgstr ""
+
+#: src/menus/main.py:697
+msgid "You went thrift shopping and found the weirdest treasures imaginable."
+msgstr ""
+
+#: src/menus/main.py:698
+msgid "You played board games all night, with dramatic accusations of cheating."
+msgstr ""
+
+#: src/menus/main.py:699
+msgid "You hiked a nearby trail, spotting wildlife and sharing ghost stories."
 msgstr ""
 
 #: src/menus/main.py:700
-msgid "You retired and are now receiving pension of ${pension}."
+msgid "You organized a talent show in the living room, with hilariously bad impressions."
+msgstr ""
+
+#: src/menus/main.py:701
+msgid "You tried street food from a food truck, rating each bite like food critics."
+msgstr ""
+
+#: src/menus/main.py:702
+msgid "You had a photo scavenger hunt around town, capturing goofy moments."
+msgstr ""
+
+#: src/menus/main.py:703
+msgid "You chilled at the beach, building sandcastles that rivaled real architecture."
 msgstr ""
 
 #: src/menus/main.py:704
-msgid "Are you sure you want to quit your job?"
+msgid "You hosted a movie marathon with themed snacks and endless commentary."
+msgstr ""
+
+#: src/menus/main.py:705
+msgid "You went roller skating, falling more times than you could count but loving it."
 msgstr ""
 
 #: src/menus/main.py:706
-msgid "You quit your job."
+msgid "You planted a mini garden together, naming each plant after a celebrity."
+msgstr ""
+
+#: src/menus/main.py:707
+msgid "You had a karaoke session, belting out tunes off-key but full of heart."
 msgstr ""
 
 #: src/menus/main.py:708
-msgid "What would you like to set your hours to? (38 - 70)"
+msgid "You explored an arcade, competing for the high score on every machine."
+msgstr ""
+
+#: src/menus/main.py:709
+msgid "You crafted DIY friendship bracelets, getting tangled in yarn and laughter."
+msgstr ""
+
+#: src/menus/main.py:710
+msgid "You went on a library adventure, recommending the weirdest books to each other."
+msgstr ""
+
+#: src/menus/main.py:711
+msgid "You had a pillow fight that escalated into an all-out feather frenzy."
 msgstr ""
 
 #: src/menus/main.py:712
-msgid "Your request for a raise has been approved."
+msgid "You tried yoga in the park, ending up in a pile of giggles instead of zen."
 msgstr ""
 
-#: src/menus/main.py:715
-msgid "You got a raise of {perc}%"
+#: src/menus/main.py:713
+msgid "You shared secrets and dreams under a tree, strengthening your bonds."
 msgstr ""
 
-#: src/menus/main.py:719
-msgid "Your request for a raise has been rejected."
+#: src/menus/main.py:714
+msgid "You invented a new game combining tag and hide-and-seek with silly rules."
 msgstr ""
 
-#: src/menus/main.py:721
-msgid "Your boss fired you for asking for a raise."
+#: src/menus/main.py:724
+msgid "You're too tired to study with classmates."
+msgstr ""
+
+#: src/menus/main.py:727
+msgid "You and your friends reviewed math problems at the library."
+msgstr ""
+
+#: src/menus/main.py:728
+msgid "You studied history together at a cafe."
 msgstr ""
 
 #: src/menus/main.py:729
-msgid "No previously saved games"
+msgid "You quizzed each other for the science test."
+msgstr ""
+
+#: src/menus/main.py:730
+msgid "You formed a virtual study group online."
 msgstr ""
 
 #: src/menus/main.py:731
-msgid "Previously saved games:"
+msgid "You and your friends reviewed math problems at the library, turning equations into a game of 'solve or snack'."
+msgstr ""
+
+#: src/menus/main.py:732
+msgid "You studied history together at a cafe, reenacting battles with sugar packets and straws."
+msgstr ""
+
+#: src/menus/main.py:733
+msgid "You quizzed each other for the science test, making up goofy mnemonics that had everyone in stitches."
+msgstr ""
+
+#: src/menus/main.py:734
+msgid "You formed a virtual study group online, with everyone accidentally leaving their mics on during snack breaks."
+msgstr ""
+
+#: src/menus/main.py:735
+msgid "You tackled literature notes in the park, dramatically reading passages like Shakespearean actors."
+msgstr ""
+
+#: src/menus/main.py:736
+msgid "You crammed for biology at a friend's house, drawing cell diagrams in chalk on the driveway."
+msgstr ""
+
+#: src/menus/main.py:737
+msgid "You worked on chemistry problems in the school lab, pretending to be mad scientists with wild hair."
+msgstr ""
+
+#: src/menus/main.py:738
+msgid "You studied foreign language vocab at a diner, shouting phrases over milkshakes and fries."
 msgstr ""
 
 #: src/menus/main.py:739
-msgid "Delete Save"
+msgid "You reviewed physics concepts at the skate park, comparing ramps to projectile motion."
 msgstr ""
 
-#: src/menus/main.py:739
-msgid "Load Save"
+#: src/menus/main.py:740
+msgid "You group-studied for English, writing absurd short stories to test grammar rules."
 msgstr ""
 
 #: src/menus/main.py:741
-msgid "Would you like to load this save?"
+msgid "You dove into computer science at a tech shop, debugging code while surrounded by gadget chaos."
+msgstr ""
+
+#: src/menus/main.py:742
+msgid "You practiced debate skills in the library, arguing silly topics like 'cats vs. dogs' for fun."
+msgstr ""
+
+#: src/menus/main.py:743
+msgid "You studied geography by mapping out a fictional world on a giant poster board."
+msgstr ""
+
+#: src/menus/main.py:744
+msgid "You tackled algebra together in a treehouse, solving equations while munching on candy."
+msgstr ""
+
+#: src/menus/main.py:745
+msgid "You prepped for a history exam at the museum, whispering facts in front of ancient artifacts."
+msgstr ""
+
+#: src/menus/main.py:746
+msgid "You worked on art history in a gallery, sketching replicas of famous paintings with crayons."
 msgstr ""
 
 #: src/menus/main.py:747
+msgid "You studied music theory in a garage, banging on pots and pans to understand rhythm."
+msgstr ""
+
+#: src/menus/main.py:748
+msgid "You reviewed economics at the mall, analyzing fake budgets for a dream shopping spree."
+msgstr ""
+
+#: src/menus/main.py:749
+msgid "You quizzed each other on psychology terms, diagnosing your study group's 'procrastination syndrome'."
+msgstr ""
+
+#: src/menus/main.py:750
+msgid "You studied environmental science by the lake, debating solutions while skipping rocks."
+msgstr ""
+
+#: src/menus/main.py:751
+msgid "You tackled trigonometry in a backyard, using a protractor to measure angles of a swing set."
+msgstr ""
+
+#: src/menus/main.py:752
+msgid "You formed a flashcards frenzy at a pizza place, tossing cards like confetti for correct answers."
+msgstr ""
+
+#: src/menus/main.py:753
+msgid "You studied astronomy under the stars, pointing out constellations with a laser pointer."
+msgstr ""
+
+#: src/menus/main.py:754
+msgid "You worked on group projects in a basement, turning research into a podcast recording session."
+msgstr ""
+
+#: src/menus/main.py:755
+msgid "You reviewed philosophy in a coffee shop, debating life's big questions over lattes."
+msgstr ""
+
+#: src/menus/main.py:767
+msgid "You're too tired to gossip."
+msgstr ""
+
+#: src/menus/main.py:770
+msgid "You spread a rumor about a classmate."
+msgstr ""
+
+#: src/menus/main.py:771
+msgid "You talked about the latest drama in school."
+msgstr ""
+
+#: src/menus/main.py:772
+msgid "You whispered secrets with a friend."
+msgstr ""
+
+#: src/menus/main.py:773
+msgid "You accidentally gossiped about the wrong person!"
+msgstr ""
+
+#: src/menus/main.py:774
+msgid "You spread a juicy rumor about a classmate's secret talent for yodeling in the shower."
+msgstr ""
+
+#: src/menus/main.py:775
+msgid "You dished about the latest school drama over lunch, complete with wild theories about who started it."
+msgstr ""
+
+#: src/menus/main.py:776
+msgid "You whispered secrets with a friend behind the bleachers, giggling so hard you almost got caught."
+msgstr ""
+
+#: src/menus/main.py:777
+msgid "You accidentally gossiped about the wrong person and now everyone's talking about your mix-up!"
+msgstr ""
+
+#: src/menus/main.py:778
+msgid "You overheard a wild story about the principal's secret karaoke nights and shared it with the squad."
+msgstr ""
+
+#: src/menus/main.py:779
+msgid "You speculated about who left a love note in the library, creating a school-wide mystery."
+msgstr ""
+
+#: src/menus/main.py:780
+msgid "You traded gossip about the cafeteria’s mystery meat recipe, swearing it’s alien food."
+msgstr ""
+
+#: src/menus/main.py:781
+msgid "You and your bestie debated whether the new kid is secretly a movie star in disguise."
+msgstr ""
+
+#: src/menus/main.py:782
+msgid "You passed on a rumor that the math teacher’s chalkboard doodles are coded messages."
+msgstr ""
+
+#: src/menus/main.py:783
+msgid "You shared a hot tip about a secret party happening in the old gym this weekend."
+msgstr ""
+
+#: src/menus/main.py:784
+msgid "You got the scoop on why the school mascot costume smells like tacos and told everyone."
+msgstr ""
+
+#: src/menus/main.py:785
+msgid "You whispered about a classmate’s epic prank that turned the fountain bright pink."
+msgstr ""
+
+#: src/menus/main.py:786
+msgid "You spread a tale about a haunted locker that only opens at midnight."
+msgstr ""
+
+#: src/menus/main.py:787
+msgid "You gossiped about who’s been sneaking extra cookies from the bake sale table."
+msgstr ""
+
+#: src/menus/main.py:788
+msgid "You shared a wild guess about the gym teacher’s secret life as a roller derby champ."
+msgstr ""
+
+#: src/menus/main.py:789
+msgid "You and your crew debated who’s behind the anonymous advice column in the school paper."
+msgstr ""
+
+#: src/menus/main.py:790
+msgid "You let slip a rumor about a teacher’s pet parrot that swears in three languages."
+msgstr ""
+
+#: src/menus/main.py:791
+msgid "You traded stories about a classmate’s legendary dance moves at the talent show."
+msgstr ""
+
+#: src/menus/main.py:792
+msgid "You whispered about a secret club that meets in the janitor’s closet after hours."
+msgstr ""
+
+#: src/menus/main.py:793
+msgid "You speculated on who keeps leaving glitter bombs in the hallways for fun."
+msgstr ""
+
+#: src/menus/main.py:794
+msgid "You shared a theory that the school’s Wi-Fi outages are caused by a rogue hacker clique."
+msgstr ""
+
+#: src/menus/main.py:795
+msgid "You giggled over gossip about a classmate’s bizarre collection of vintage lunchboxes."
+msgstr ""
+
+#: src/menus/main.py:796
+msgid "You passed on a rumor that the science lab skeleton is actually a retired pirate’s bones."
+msgstr ""
+
+#: src/menus/main.py:797
+msgid "You dished about a teacher’s coffee addiction, claiming they hide espresso in their water bottle."
+msgstr ""
+
+#: src/menus/main.py:798
+msgid "You spread word of a secret handshake that only the cool kids know—now everyone’s trying it."
+msgstr ""
+
+#: src/menus/main.py:808
+msgid "Your parents ask you to {task}. Do you comply?"
+msgstr ""
+
+#: src/menus/main.py:812
+msgid "Your parents are pleased."
+msgstr ""
+
+#: src/menus/main.py:815
+msgid "Your parents are disappointed."
+msgstr ""
+
+#: src/menus/main.py:818
+msgid "Your teacher asks you to {task}. Do you comply?"
+msgstr ""
+
+#: src/menus/main.py:822
+msgid "Your teacher appreciates your effort."
+msgstr ""
+
+#: src/menus/main.py:825
+msgid "You declined the request."
+msgstr ""
+
+#: src/menus/main.py:831
+msgid "You're too tired."
+msgstr ""
+
+#: src/menus/main.py:836
+msgid "Requirements for {club}:"
+msgstr ""
+
+#: src/menus/main.py:846
+msgid "You joined the {club}."
+msgstr ""
+
+#: src/menus/main.py:857
+msgid "You don't meet the requirements for the {club}."
+msgstr ""
+
+#: src/menus/main.py:862
+msgid "You are already in a club."
+msgstr ""
+
+#: src/menus/main.py:865
+msgid "You're too tired to start a project."
+msgstr ""
+
+#: src/menus/main.py:878
+msgid "You're too tired to ask questions."
+msgstr ""
+
+#: src/menus/main.py:889
+msgid "You asked how to apply calculus to physics."
+msgstr ""
+
+#: src/menus/main.py:890
+msgid "You wondered about solving quadratic equations."
+msgstr ""
+
+#: src/menus/main.py:893
+msgid "You asked about the use of metaphors."
+msgstr ""
+
+#: src/menus/main.py:894
+msgid "You discussed nuances of grammar."
+msgstr ""
+
+#: src/menus/main.py:897
+msgid "You asked about quantum mechanics."
+msgstr ""
+
+#: src/menus/main.py:898
+msgid "You questioned how photosynthesis works."
+msgstr ""
+
+#: src/menus/main.py:903
+msgid "You asked if 1+1 always equals 2."
+msgstr ""
+
+#: src/menus/main.py:904
+msgid "You wondered why we need numbers."
+msgstr ""
+
+#: src/menus/main.py:907
+msgid "You asked if 'cat' is a verb."
+msgstr ""
+
+#: src/menus/main.py:908
+msgid "You questioned why spelling matters."
+msgstr ""
+
+#: src/menus/main.py:911
+msgid "You asked if the sun is made of fire."
+msgstr ""
+
+#: src/menus/main.py:912
+msgid "You wondered why water is wet."
+msgstr ""
+
+#: src/menus/main.py:923
+msgid "You're too tired to help."
+msgstr ""
+
+#: src/menus/main.py:926
+msgid "You helped a classmate with homework."
+msgstr ""
+
+#: src/menus/main.py:927
+msgid "You defended a classmate from a bully."
+msgstr ""
+
+#: src/menus/main.py:928
+msgid "You shared your notes with a classmate."
+msgstr ""
+
+#: src/menus/main.py:929
+msgid "You helped carry books for a classmate."
+msgstr ""
+
+#: src/menus/main.py:938 src/menus/main.py:996
+msgid "You're too tired for sports."
+msgstr ""
+
+#: src/menus/main.py:943 src/menus/main.py:1001
+msgid "Requirements for {sport} team:"
+msgstr ""
+
+#: src/menus/main.py:955 src/menus/main.py:1011
+msgid "You joined the {sport} team."
+msgstr ""
+
+#: src/menus/main.py:966 src/menus/main.py:1022
+msgid "You don't meet the requirements for the {sport} team."
+msgstr ""
+
+#: src/menus/main.py:971 src/menus/main.py:1027
+msgid "You are already on a sports team."
+msgstr ""
+
+#: src/menus/main.py:975
+msgid "You already chose a career aspiration: {asp}."
+msgstr ""
+
+#: src/menus/main.py:980
+msgid "You now aspire to a career in {asp}."
+msgstr ""
+
+#: src/menus/main.py:984
+msgid "You're too tired to pick an elective."
+msgstr ""
+
+#: src/menus/main.py:986
+msgid "Which elective will you choose?"
+msgstr ""
+
+#: src/menus/main.py:987
+msgid "Computer"
+msgstr ""
+
+#: src/menus/main.py:987
+msgid "Foreign language"
+msgstr ""
+
+#: src/menus/main.py:1030
+msgid "You're too tired for study group."
+msgstr ""
+
+#: src/menus/main.py:1032
+msgid "You participated in a study group."
+msgstr ""
+
+#: src/menus/main.py:1039
+msgid "You're too tired for student council."
+msgstr ""
+
+#: src/menus/main.py:1041
+msgid "You joined the student council."
+msgstr ""
+
+#: src/menus/main.py:1047
+msgid "You are already on the student council."
+msgstr ""
+
+#: src/menus/main.py:1050
+msgid "You're too tired to deal with this."
+msgstr ""
+
+#: src/menus/main.py:1052
+msgid "A bully confronts you. How do you respond?"
+msgstr ""
+
+#: src/menus/main.py:1053
+msgid "Ignore"
+msgstr ""
+
+#: src/menus/main.py:1053
+msgid "Report to teacher"
+msgstr ""
+
+#: src/menus/main.py:1053
+msgid "Stand up"
+msgstr ""
+
+#: src/menus/main.py:1060
+msgid "You stood up to the bully successfully."
+msgstr ""
+
+#: src/menus/main.py:1063
+msgid "The bully intimidated you."
+msgstr ""
+
+#: src/menus/main.py:1070
+msgid "You need to set a career aspiration before enrolling in advanced courses."
+msgstr ""
+
+#: src/menus/main.py:1072
+msgid "You're too tired for advanced courses."
+msgstr ""
+
+#: src/menus/main.py:1075
+msgid "You enrolled in the {course}."
+msgstr ""
+
+#: src/menus/main.py:1083
+msgid "You're too tired for leadership roles."
+msgstr ""
+
+#: src/menus/main.py:1085
+msgid "You took on an extracurricular leadership role."
+msgstr ""
+
+#: src/menus/main.py:1091
+msgid "You are already a student leader."
+msgstr ""
+
+#: src/menus/main.py:1094
+msgid "You're too tired to go to prom."
+msgstr ""
+
+#: src/menus/main.py:1096
+msgid "You went to prom."
+msgstr ""
+
+#: src/menus/main.py:1102
+msgid "You quit your part-time job to study more."
+msgstr ""
+
+#: src/menus/main.py:1107
+msgid "You're too tired to start working."
+msgstr ""
+
+#: src/menus/main.py:1109
+msgid "You started a part-time job."
+msgstr ""
+
+#: src/menus/main.py:1119
+msgid "You're too tired for tests."
+msgstr ""
+
+#: src/menus/main.py:1121
+msgid "You took college prep tests."
+msgstr ""
+
+#: src/menus/main.py:1129
+msgid "Identity"
+msgstr ""
+
+#: src/menus/main.py:1129
+msgid "Stats"
+msgstr ""
+
+#: src/menus/main.py:1133
+msgid "Your stats"
+msgstr ""
+
+#: src/menus/main.py:1134 src/people/classes/player.py:885
+msgid "Happiness"
+msgstr ""
+
+#: src/menus/main.py:1140
+msgid "The below stats only matter if you have a job:"
+msgstr ""
+
+#: src/menus/main.py:1141 src/menus/main.py:1258
+#: src/people/classes/player.py:891
+msgid "Stress"
+msgstr ""
+
+#: src/menus/main.py:1142 src/menus/main.py:1258
+msgid "Performance"
+msgstr ""
+
+#: src/menus/main.py:1146
+msgid "Modify Happiness"
+msgstr ""
+
+#: src/menus/main.py:1147
+msgid "Modify Health"
+msgstr ""
+
+#: src/menus/main.py:1148
+msgid "Modify Smarts"
+msgstr ""
+
+#: src/menus/main.py:1149
+msgid "Modify Looks"
+msgstr ""
+
+#: src/menus/main.py:1150
+msgid "Modify Karma"
+msgstr ""
+
+#: src/menus/main.py:1151
+msgid "Modify Stress"
+msgstr ""
+
+#: src/menus/main.py:1152
+msgid "Modify Performance"
+msgstr ""
+
+#: src/menus/main.py:1157
+msgid "What would you like to set Happiness to? (0-100)"
+msgstr ""
+
+#: src/menus/main.py:1162
+msgid "What would you like to set Health to? (0-100)"
+msgstr ""
+
+#: src/menus/main.py:1167
+msgid "What would you like to set Smarts to? (0-100)"
+msgstr ""
+
+#: src/menus/main.py:1172
+msgid "What would you like to set Looks to? (0-100)"
+msgstr ""
+
+#: src/menus/main.py:1177
+msgid "What would you like to set Karma to? (0-100)"
+msgstr ""
+
+#: src/menus/main.py:1182
+msgid "What would you like to set Stress to? (0-100)"
+msgstr ""
+
+#: src/menus/main.py:1187
+msgid "What would you like to set Performance to? (0-100)"
+msgstr ""
+
+#: src/menus/main.py:1194
+msgid "First name"
+msgstr ""
+
+#: src/menus/main.py:1195
+msgid "Last name"
+msgstr ""
+
+#: src/menus/main.py:1199
+msgid "Change first name"
+msgstr ""
+
+#: src/menus/main.py:1200
+msgid "Change last name"
+msgstr ""
+
+#: src/menus/main.py:1201
+msgid "Change gender"
+msgstr ""
+
+#: src/menus/main.py:1206
+msgid "Enter first name: "
+msgstr ""
+
+#: src/menus/main.py:1210
+msgid "Enter last name: "
+msgstr ""
+
+#: src/menus/main.py:1230
+msgid "You found a job as a {title} with a salary of ${salary:,}. Would you like to apply?"
+msgstr ""
+
+#: src/menus/main.py:1244
+msgid "You got the job!"
+msgstr ""
+
+#: src/menus/main.py:1248
+msgid "You didn't get an interview."
+msgstr ""
+
+#: src/menus/main.py:1253
+msgid "Your job"
+msgstr ""
+
+#: src/menus/main.py:1260
+msgid "Hours"
+msgstr ""
+
+#: src/menus/main.py:1264
+msgid "Work Harder"
+msgstr ""
+
+#: src/menus/main.py:1265
+msgid "Quit Job"
+msgstr ""
+
+#: src/menus/main.py:1265
+msgid "Retire"
+msgstr ""
+
+#: src/menus/main.py:1266
+msgid "Adjust Hours"
+msgstr ""
+
+#: src/menus/main.py:1267
+msgid "Request a Raise"
+msgstr ""
+
+#: src/menus/main.py:1281
+msgid "Do you want to retire? You will receive a yearly pension of ${pension}"
+msgstr ""
+
+#: src/menus/main.py:1289
+msgid "You retired and are now receiving pension of ${pension}."
+msgstr ""
+
+#: src/menus/main.py:1293
+msgid "Are you sure you want to quit your job?"
+msgstr ""
+
+#: src/menus/main.py:1295
+msgid "You quit your job."
+msgstr ""
+
+#: src/menus/main.py:1297
+msgid "What would you like to set your hours to? (38 - 70)"
+msgstr ""
+
+#: src/menus/main.py:1301
+msgid "Your request for a raise has been approved."
+msgstr ""
+
+#: src/menus/main.py:1304
+msgid "You got a raise of {perc}%"
+msgstr ""
+
+#: src/menus/main.py:1308
+msgid "Your request for a raise has been rejected."
+msgstr ""
+
+#: src/menus/main.py:1310
+msgid "Your boss fired you for asking for a raise."
+msgstr ""
+
+#: src/menus/main.py:1318
+msgid "No previously saved games"
+msgstr ""
+
+#: src/menus/main.py:1320
+msgid "Previously saved games:"
+msgstr ""
+
+#: src/menus/main.py:1328
+msgid "Delete Save"
+msgstr ""
+
+#: src/menus/main.py:1328
+msgid "Load Save"
+msgstr ""
+
+#: src/menus/main.py:1330
+msgid "Would you like to load this save?"
+msgstr ""
+
+#: src/menus/main.py:1336
 msgid "Are you sure you want to delete this save?"
 msgstr ""
 
@@ -16317,11 +17324,11 @@ msgstr ""
 msgid "Choose your gender:"
 msgstr ""
 
-#: src/menus/start.py:26 src/people/classes/player.py:647
+#: src/menus/start.py:26 src/people/classes/player.py:842
 msgid "Female"
 msgstr ""
 
-#: src/menus/start.py:26 src/people/classes/player.py:647
+#: src/menus/start.py:26 src/people/classes/player.py:842
 msgid "Male"
 msgstr ""
 
@@ -16509,472 +17516,684 @@ msgstr ""
 msgid "Wife"
 msgstr ""
 
-#: src/people/classes/player.py:120
+#: src/people/classes/player.py:144
+msgid "Reach adulthood (age 18)"
+msgstr ""
+
+#: src/people/classes/player.py:149
+msgid "Get a job"
+msgstr ""
+
+#: src/people/classes/player.py:151
+msgid "Employed"
+msgstr ""
+
+#: src/people/classes/player.py:154
+msgid "Accumulate $100,000"
+msgstr ""
+
+#: src/people/classes/player.py:170
+msgid "All goals completed!"
+msgstr ""
+
+#: src/people/classes/player.py:184
+msgid "Goal complete: {goal}"
+msgstr ""
+
+#: src/people/classes/player.py:188
+msgid "New goal: {goal}"
+msgstr ""
+
+#: src/people/classes/player.py:210
 msgid "You lose the {trait!r} trait!"
 msgstr ""
 
-#: src/people/classes/player.py:127
+#: src/people/classes/player.py:217
 msgid "You have gained the {trait} trait!"
 msgstr ""
 
-#: src/people/classes/player.py:202
+#: src/people/classes/player.py:292
 msgid "Your parent, {name}, passed away."
 msgstr ""
 
-#: src/people/classes/player.py:205
+#: src/people/classes/player.py:295
 msgid "They left behind cash assets of ${amount}."
 msgstr ""
 
-#: src/people/classes/player.py:206
+#: src/people/classes/player.py:296
 msgid "You inherited ${amount}."
 msgstr ""
 
-#: src/people/classes/player.py:235
+#: src/people/classes/player.py:325
 msgid "You died after sustaining massive injuries in an assault."
 msgstr ""
 
-#: src/people/classes/player.py:277
+#: src/people/classes/player.py:367
 msgid "You have the following traits:"
 msgstr ""
 
-#: src/people/classes/player.py:349
+#: src/people/classes/player.py:461
+msgid "You reached a knowledge milestone of {m}!"
+msgstr ""
+
+#: src/people/classes/player.py:470
+msgid "Achievement unlocked: Perfect Attendance"
+msgstr ""
+
+#: src/people/classes/player.py:471
+msgid "You have been invited to a special school event!"
+msgstr ""
+
+#: src/people/classes/player.py:475
+msgid "Achievement unlocked: Honor Student"
+msgstr ""
+
+#: src/people/classes/player.py:476
+msgid "Scholarship opportunities are now available."
+msgstr ""
+
+#: src/people/classes/player.py:480
+msgid "Achievement unlocked: School Celebrity"
+msgstr ""
+
+#: src/people/classes/player.py:481
+msgid "Better part-time job opportunities unlocked."
+msgstr ""
+
+#: src/people/classes/player.py:517
 msgid "died of old age"
 msgstr ""
 
-#: src/people/classes/player.py:353
+#: src/people/classes/player.py:521
 msgid ""
 "Your {relative} died at the age of {age}.\n"
 "{he_she} {reason}."
 msgstr ""
 
-#: src/people/classes/player.py:379
+#: src/people/classes/player.py:547
 msgid "Would you like to attend the funeral?"
 msgstr ""
 
-#: src/people/classes/player.py:387
+#: src/people/classes/player.py:555
+msgid "You feel intense panic as the death of your loved one reminds you of how much you are afraid of death."
+msgstr ""
+
+#: src/people/classes/player.py:559
 msgid "You inherited ${amount}"
 msgstr ""
 
-#: src/people/classes/player.py:434
+#: src/people/classes/player.py:610
 msgid "You died of old age."
 msgstr ""
 
-#: src/people/classes/player.py:459
+#: src/people/classes/player.py:635
 msgid "You suffered a miscarriage and lost the baby!"
 msgstr ""
 
-#: src/people/classes/player.py:465
+#: src/people/classes/player.py:641
 msgid "You just had a baby {son_daughter}!"
 msgstr ""
 
-#: src/people/classes/player.py:469 src/people/classes/player.py:509
+#: src/people/classes/player.py:645 src/people/classes/player.py:685
 msgid "What will you name {him_her}? (or leave blank for a random name)"
 msgstr ""
 
-#: src/people/classes/player.py:487
+#: src/people/classes/player.py:663
 msgid "You are the mother of a baby {son_daughter} named {name}."
 msgstr ""
 
-#: src/people/classes/player.py:496
+#: src/people/classes/player.py:672
 msgid "Your {partner} suffered a miscarriage and lost the baby!"
 msgstr ""
 
-#: src/people/classes/player.py:502
+#: src/people/classes/player.py:678
 msgid "Your {partner} just had a baby {son_daughter}!"
 msgstr ""
 
-#: src/people/classes/player.py:526
+#: src/people/classes/player.py:702
 msgid "You are the father of a baby {son_daughter} named {name}."
 msgstr ""
 
-#: src/people/classes/player.py:534
+#: src/people/classes/player.py:710
 msgid "You are suffering from depression."
 msgstr ""
 
-#: src/people/classes/player.py:545
+#: src/people/classes/player.py:721
 msgid "died after driving off a cliff while texting and driving"
 msgstr ""
 
-#: src/people/classes/player.py:548
+#: src/people/classes/player.py:724
 msgid "starved to death after playing this game for too many days without stopping to eat"
 msgstr ""
 
-#: src/people/classes/player.py:571
+#: src/people/classes/player.py:730
+msgid "You begin to worry that one day you may not be here anymore."
+msgstr ""
+
+#: src/people/classes/player.py:731
+msgid "You begin to panic at the thought of dying."
+msgstr ""
+
+#: src/people/classes/player.py:732
+msgid "You are afraid of dying. You feel your heart beat quickly."
+msgstr ""
+
+#: src/people/classes/player.py:733
+msgid "You feel extremely anxious at the thought of one day not being here anyone."
+msgstr ""
+
+#: src/people/classes/player.py:734
+msgid "You're afraid to die. You feel you must stay out of any situations that involve dying."
+msgstr ""
+
+#: src/people/classes/player.py:735
+msgid "The thought of dying makes your heart race and you feel anxious."
+msgstr ""
+
+#: src/people/classes/player.py:736
+msgid "You find it hard to sleep at night, afraid of even the thought of dying."
+msgstr ""
+
+#: src/people/classes/player.py:737
+msgid "You don't even want to THINK about dying."
+msgstr ""
+
+#: src/people/classes/player.py:765
 msgid "You have been forced to retire from your position."
 msgstr ""
 
-#: src/people/classes/player.py:573
+#: src/people/classes/player.py:767
 msgid "You are now receiving a yearly pension of ${pension:,}."
 msgstr ""
 
-#: src/people/classes/player.py:577
+#: src/people/classes/player.py:771
 msgid "You are eligible to retire and begin receiving a yearly pension of ${pension:,}."
 msgstr ""
 
-#: src/people/classes/player.py:578
+#: src/people/classes/player.py:772
 msgid "Would you like to retire?"
 msgstr ""
 
-#: src/people/classes/player.py:579
+#: src/people/classes/player.py:773
 msgid "You retired and are now receiving pension."
 msgstr ""
 
-#: src/people/classes/player.py:585
+#: src/people/classes/player.py:779
 msgid ""
 "You have been fired from your job.\n"
 "Reason: Performance"
 msgstr ""
 
-#: src/people/classes/player.py:589
+#: src/people/classes/player.py:783
 msgid "Your performance was {perf}%"
 msgstr ""
 
-#: src/people/classes/player.py:602
+#: src/people/classes/player.py:796
 msgid "You feel like you're on the verge of burnout from so much work!"
 msgstr ""
 
-#: src/people/classes/player.py:607
+#: src/people/classes/player.py:801
 msgid "You're feeling stressed out from all of this work."
 msgstr ""
 
-#: src/people/classes/player.py:609
+#: src/people/classes/player.py:803
 msgid "You are suffering from high blood pressure."
 msgstr ""
 
-#: src/people/classes/player.py:656
+#: src/people/classes/player.py:851
 msgid "Lifetime Happiness"
 msgstr ""
 
-#: src/people/classes/player.py:721
-msgid "The judge has ordered you to pay {name} ${amount} to settle your divorce."
-msgstr ""
-
-#: src/people/classes/player.py:735
-msgid "You were struck by lightning!"
-msgstr ""
-
-#: src/people/classes/player.py:750
-msgid "You died after being struck by lightning."
-msgstr ""
-
-#: src/people/classes/player.py:763
-msgid "You graduated from university."
-msgstr ""
-
-#: src/people/classes/player.py:768
-msgid "You now have to start paying back your student loan"
-msgstr ""
-
-#: src/people/classes/player.py:772
-msgid "You were expelled from university after earning bad grades."
-msgstr ""
-
-#: src/people/classes/player.py:781
-msgid "You've fully paid off your student loan"
-msgstr ""
-
-#: src/people/classes/player.py:785
-msgid "You are no longer suffering from depression"
-msgstr ""
-
-#: src/people/classes/player.py:796
-msgid "You died due to a massive heart attack."
-msgstr ""
-
-#: src/people/classes/player.py:799
-msgid "You are no longer suffering from high blood pressure"
-msgstr ""
-
-#: src/people/classes/player.py:808
-msgid "You died due to complications associated with cancer."
-msgstr ""
-
-#: src/people/classes/player.py:812
-msgid "You have been diagnosed with cancer."
-msgstr ""
-
-#: src/people/classes/player.py:813
-msgid "Cancer"
-msgstr ""
-
-#: src/people/classes/player.py:818
-msgid "You are suffering from the flu."
-msgstr ""
-
-#: src/people/classes/player.py:819
-msgid "Flu"
-msgstr ""
-
-#: src/people/classes/player.py:823
-msgid "You are suffering from the common cold."
-msgstr ""
-
-#: src/people/classes/player.py:824
-msgid "Common Cold"
-msgstr ""
-
-#: src/people/classes/player.py:829
-msgid "Your mother is taking to to the doctor's office to get vaccinated."
-msgstr ""
-
-#: src/people/classes/player.py:831
-msgid "How will you behave?"
-msgstr ""
-
-#: src/people/classes/player.py:833
-msgid "Try to stay calm"
-msgstr ""
-
-#: src/people/classes/player.py:834
-msgid "Throw a conniption fit"
-msgstr ""
-
-#: src/people/classes/player.py:834
-msgid "Throw a tantrum"
-msgstr ""
-
-#: src/people/classes/player.py:835
-msgid "Bite her"
-msgstr ""
-
-#: src/people/classes/player.py:840
-msgid "You remained calm"
-msgstr ""
-
-#: src/people/classes/player.py:844
-msgid "You threw a tantrum"
-msgstr ""
-
-#: src/people/classes/player.py:848
-msgid "You bit your mother"
-msgstr ""
-
-#: src/people/classes/player.py:866
-msgid "You are starting elementary school"
-msgstr ""
-
-#: src/people/classes/player.py:870
-msgid "You are starting middle school"
-msgstr ""
-
-#: src/people/classes/player.py:874
-msgid "You are starting high school"
-msgstr ""
-
-#: src/people/classes/player.py:881
-msgid "Your {partner} wants to break up with you."
-msgstr ""
-
-#: src/people/classes/player.py:883 src/people/classes/player.py:930
-#: src/people/classes/player.py:982
-msgid "What will you do?"
-msgstr ""
-
-#: src/people/classes/player.py:886 src/people/classes/player.py:933
-msgid "Wish {him_her} well"
-msgstr ""
-
-#: src/people/classes/player.py:887 src/people/classes/player.py:934
-msgid "Beg {him_her} to stay"
-msgstr ""
-
-#: src/people/classes/player.py:888 src/people/classes/player.py:935
-msgid "Insult {him_her} one last time"
-msgstr ""
-
-#: src/people/classes/player.py:893
-msgid "You wished {name} the best"
-msgstr ""
-
-#: src/people/classes/player.py:898 src/people/classes/player.py:947
-msgid "You begged {name} to stay with you."
-msgstr ""
-
-#: src/people/classes/player.py:905
-msgid "{he_she} dumped you anyway."
-msgstr ""
-
-#: src/people/classes/player.py:911 src/people/classes/player.py:960
-msgid "{he_she} decided to stay with you."
+#: src/people/classes/player.py:890
+msgid "Energy"
 msgstr ""
 
 #: src/people/classes/player.py:919
-msgid "{name} broke up with you."
-msgstr ""
-
-#: src/people/classes/player.py:921 src/people/classes/player.py:972
-msgid "You called {him_her} {insult} as {he_she} was walking out the door."
-msgstr ""
-
-#: src/people/classes/player.py:929
-msgid "Your {partner} wants a divorce."
-msgstr ""
-
-#: src/people/classes/player.py:940
-msgid "You honored {name}'s request for a divorce."
-msgstr ""
-
-#: src/people/classes/player.py:954
-msgid "{he_she} insisted on getting a divorce."
-msgstr ""
-
-#: src/people/classes/player.py:970
-msgid "{name} divorced you."
-msgstr ""
-
-#: src/people/classes/player.py:980
-msgid "Your {partner} has been kidnapped and is being held for ${ransom} ransom!"
+msgid "The judge has ordered you to pay {name} ${amount} to settle your divorce."
 msgstr ""
 
 #: src/people/classes/player.py:981
-msgid "The kidnappers warn you not to involve the police."
-msgstr ""
-
-#: src/people/classes/player.py:985
-msgid "Pay the ransom"
-msgstr ""
-
-#: src/people/classes/player.py:986
-msgid "Involve the police"
+msgid "Exam time! What is {a} + {b}?"
 msgstr ""
 
 #: src/people/classes/player.py:987
-msgid "Do nothing"
+msgid "You passed the exam."
 msgstr ""
 
-#: src/people/classes/player.py:994
-msgid "You successfully paid ${ransom} ransom in exchange for {name}'s release."
+#: src/people/classes/player.py:992
+msgid "You failed the exam."
 msgstr ""
 
-#: src/people/classes/player.py:996
-msgid "You paid ${ransom} ransom but they did not return {name}!"
+#: src/people/classes/player.py:1021
+msgid "Your class is going on a trip that costs ${cost}. Do you want to go?"
 msgstr ""
 
-#: src/people/classes/player.py:1000
-msgid "The police managed to secure {name}'s release and arrest the kidnappers!"
+#: src/people/classes/player.py:1025
+msgid "Join the trip"
 msgstr ""
 
-#: src/people/classes/player.py:1002
-msgid "The police were unable to secure {name}'s release!"
+#: src/people/classes/player.py:1025
+msgid "Stay home"
 msgstr ""
 
-#: src/people/classes/player.py:1004
-msgid "You did absolutely nothing!"
+#: src/people/classes/player.py:1032
+msgid "You can't afford to go."
 msgstr ""
 
-#: src/people/classes/player.py:1010
-msgid "{name} and {his_her} kidnappers vanished!"
+#: src/people/classes/player.py:1034
+msgid "Your school is hosting a science fair. Do you want to enter?"
 msgstr ""
 
-#: src/people/classes/player.py:1011
-msgid "is presumed dead after disappearing"
+#: src/people/classes/player.py:1035
+msgid "Enter"
 msgstr ""
 
-#: src/people/classes/player.py:1020
-msgid "A female"
+#: src/people/classes/player.py:1035 src/people/classes/player.py:1056
+msgid "Skip"
 msgstr ""
 
-#: src/people/classes/player.py:1020
-msgid "A male"
+#: src/people/classes/player.py:1039
+msgid "Your project was a hit!"
 msgstr ""
 
-#: src/people/classes/player.py:1022
-msgid "{a_male_female} named {name} has asked you out."
+#: src/people/classes/player.py:1043
+msgid "Your project failed to impress."
 msgstr ""
 
-#: src/people/classes/player.py:1028
-msgid "Start dating {him_her}"
-msgstr ""
-
-#: src/people/classes/player.py:1029
-msgid "Reject {him_her}"
-msgstr ""
-
-#: src/people/classes/player.py:1038
-msgid "You graduated from high school."
-msgstr ""
-
-#: src/people/classes/player.py:1044
-msgid "Would you like to apply to university?"
-msgstr ""
-
-#: src/people/classes/player.py:1049
-msgid "Your application to university was accepted!"
-msgstr ""
-
-#: src/people/classes/player.py:1051
-msgid "Scholarship"
+#: src/people/classes/player.py:1046
+msgid "Teachers are on strike. School is closed for a week."
 msgstr ""
 
 #: src/people/classes/player.py:1052
-msgid "Student Loan"
+msgid "Your school is holding a {comp} competition. Do you take part?"
 msgstr ""
 
-#: src/people/classes/player.py:1053
-msgid "Ask parents to pay"
+#: src/people/classes/player.py:1056
+msgid "Participate"
 msgstr ""
 
-#: src/people/classes/player.py:1059
-msgid "How would you like to pay for your college tuition?"
+#: src/people/classes/player.py:1061
+msgid "You won the competition!"
 msgstr ""
 
-#: src/people/classes/player.py:1065
-msgid "Your scholarship application has been awarded!"
+#: src/people/classes/player.py:1066
+msgid "You lost the competition."
+msgstr ""
+
+#: src/people/classes/player.py:1069
+msgid "You have an important test coming up. Do you cheat?"
+msgstr ""
+
+#: src/people/classes/player.py:1070
+msgid "Cheat"
+msgstr ""
+
+#: src/people/classes/player.py:1070
+msgid "Take test honestly"
 msgstr ""
 
 #: src/people/classes/player.py:1073
-msgid "Your scholarship application was rejected."
+msgid "You were caught cheating!"
 msgstr ""
 
-#: src/people/classes/player.py:1083
-msgid "Your parents agreed to pay for your university tuition!"
+#: src/people/classes/player.py:1078
+msgid "You cheated and got away with it."
+msgstr ""
+
+#: src/people/classes/player.py:1085
+msgid "You notice a classmate cheating on an exam. What do you do?"
+msgstr ""
+
+#: src/people/classes/player.py:1087
+msgid "Ignore it"
+msgstr ""
+
+#: src/people/classes/player.py:1087
+msgid "Report to the teacher"
 msgstr ""
 
 #: src/people/classes/player.py:1093
+msgid "You decided not to get involved."
+msgstr ""
+
+#: src/people/classes/player.py:1095
+msgid "A teacher asks you to help organize supplies after class."
+msgstr ""
+
+#: src/people/classes/player.py:1096
+msgid "Decline"
+msgstr ""
+
+#: src/people/classes/player.py:1096
+msgid "Help"
+msgstr ""
+
+#: src/people/classes/player.py:1108
+msgid "You were struck by lightning!"
+msgstr ""
+
+#: src/people/classes/player.py:1123
+msgid "You died after being struck by lightning."
+msgstr ""
+
+#: src/people/classes/player.py:1132
+msgid "You graduated from university."
+msgstr ""
+
+#: src/people/classes/player.py:1137
+msgid "You now have to start paying back your student loan"
+msgstr ""
+
+#: src/people/classes/player.py:1141
+msgid "You were expelled from university after earning bad grades."
+msgstr ""
+
+#: src/people/classes/player.py:1150
+msgid "You've fully paid off your student loan"
+msgstr ""
+
+#: src/people/classes/player.py:1154
+msgid "You are no longer suffering from depression"
+msgstr ""
+
+#: src/people/classes/player.py:1165
+msgid "You died due to a massive heart attack."
+msgstr ""
+
+#: src/people/classes/player.py:1168
+msgid "You are no longer suffering from high blood pressure"
+msgstr ""
+
+#: src/people/classes/player.py:1177
+msgid "You died due to complications associated with cancer."
+msgstr ""
+
+#: src/people/classes/player.py:1181
+msgid "You have been diagnosed with cancer."
+msgstr ""
+
+#: src/people/classes/player.py:1187
+msgid "You are suffering from the flu."
+msgstr ""
+
+#: src/people/classes/player.py:1192
+msgid "You are suffering from the common cold."
+msgstr ""
+
+#: src/people/classes/player.py:1198
+msgid "Your mother is taking to to the doctor's office to get vaccinated."
+msgstr ""
+
+#: src/people/classes/player.py:1200
+msgid "How will you behave?"
+msgstr ""
+
+#: src/people/classes/player.py:1202
+msgid "Try to stay calm"
+msgstr ""
+
+#: src/people/classes/player.py:1203
+msgid "Throw a conniption fit"
+msgstr ""
+
+#: src/people/classes/player.py:1203
+msgid "Throw a tantrum"
+msgstr ""
+
+#: src/people/classes/player.py:1204
+msgid "Bite her"
+msgstr ""
+
+#: src/people/classes/player.py:1209
+msgid "You remained calm"
+msgstr ""
+
+#: src/people/classes/player.py:1213
+msgid "You threw a tantrum"
+msgstr ""
+
+#: src/people/classes/player.py:1217
+msgid "You bit your mother"
+msgstr ""
+
+#: src/people/classes/player.py:1238
+msgid "You are starting elementary school"
+msgstr ""
+
+#: src/people/classes/player.py:1242
+msgid "You are starting middle school"
+msgstr ""
+
+#: src/people/classes/player.py:1246
+msgid "You are starting high school"
+msgstr ""
+
+#: src/people/classes/player.py:1253
+msgid "Your {partner} wants to break up with you."
+msgstr ""
+
+#: src/people/classes/player.py:1255 src/people/classes/player.py:1302
+#: src/people/classes/player.py:1354
+msgid "What will you do?"
+msgstr ""
+
+#: src/people/classes/player.py:1258 src/people/classes/player.py:1305
+msgid "Wish {him_her} well"
+msgstr ""
+
+#: src/people/classes/player.py:1259 src/people/classes/player.py:1306
+msgid "Beg {him_her} to stay"
+msgstr ""
+
+#: src/people/classes/player.py:1260 src/people/classes/player.py:1307
+msgid "Insult {him_her} one last time"
+msgstr ""
+
+#: src/people/classes/player.py:1265
+msgid "You wished {name} the best"
+msgstr ""
+
+#: src/people/classes/player.py:1270 src/people/classes/player.py:1319
+msgid "You begged {name} to stay with you."
+msgstr ""
+
+#: src/people/classes/player.py:1277
+msgid "{he_she} dumped you anyway."
+msgstr ""
+
+#: src/people/classes/player.py:1283 src/people/classes/player.py:1332
+msgid "{he_she} decided to stay with you."
+msgstr ""
+
+#: src/people/classes/player.py:1291
+msgid "{name} broke up with you."
+msgstr ""
+
+#: src/people/classes/player.py:1293 src/people/classes/player.py:1344
+msgid "You called {him_her} {insult} as {he_she} was walking out the door."
+msgstr ""
+
+#: src/people/classes/player.py:1301
+msgid "Your {partner} wants a divorce."
+msgstr ""
+
+#: src/people/classes/player.py:1312
+msgid "You honored {name}'s request for a divorce."
+msgstr ""
+
+#: src/people/classes/player.py:1326
+msgid "{he_she} insisted on getting a divorce."
+msgstr ""
+
+#: src/people/classes/player.py:1342
+msgid "{name} divorced you."
+msgstr ""
+
+#: src/people/classes/player.py:1352
+msgid "Your {partner} has been kidnapped and is being held for ${ransom} ransom!"
+msgstr ""
+
+#: src/people/classes/player.py:1353
+msgid "The kidnappers warn you not to involve the police."
+msgstr ""
+
+#: src/people/classes/player.py:1357
+msgid "Pay the ransom"
+msgstr ""
+
+#: src/people/classes/player.py:1358
+msgid "Involve the police"
+msgstr ""
+
+#: src/people/classes/player.py:1359
+msgid "Do nothing"
+msgstr ""
+
+#: src/people/classes/player.py:1366
+msgid "You successfully paid ${ransom} ransom in exchange for {name}'s release."
+msgstr ""
+
+#: src/people/classes/player.py:1368
+msgid "You paid ${ransom} ransom but they did not return {name}!"
+msgstr ""
+
+#: src/people/classes/player.py:1372
+msgid "The police managed to secure {name}'s release and arrest the kidnappers!"
+msgstr ""
+
+#: src/people/classes/player.py:1374
+msgid "The police were unable to secure {name}'s release!"
+msgstr ""
+
+#: src/people/classes/player.py:1376
+msgid "You did absolutely nothing!"
+msgstr ""
+
+#: src/people/classes/player.py:1382
+msgid "{name} and {his_her} kidnappers vanished!"
+msgstr ""
+
+#: src/people/classes/player.py:1383
+msgid "is presumed dead after disappearing"
+msgstr ""
+
+#: src/people/classes/player.py:1392
+msgid "A female"
+msgstr ""
+
+#: src/people/classes/player.py:1392
+msgid "A male"
+msgstr ""
+
+#: src/people/classes/player.py:1394
+msgid "{a_male_female} named {name} has asked you out."
+msgstr ""
+
+#: src/people/classes/player.py:1400
+msgid "Start dating {him_her}"
+msgstr ""
+
+#: src/people/classes/player.py:1401
+msgid "Reject {him_her}"
+msgstr ""
+
+#: src/people/classes/player.py:1410
+msgid "You graduated from high school."
+msgstr ""
+
+#: src/people/classes/player.py:1414
+msgid "Your student council service stands out on applications."
+msgstr ""
+
+#: src/people/classes/player.py:1417
+msgid "Your college prep scores earned you scholarship offers."
+msgstr ""
+
+#: src/people/classes/player.py:1420
+msgid "Your achievements granted you a special scholarship."
+msgstr ""
+
+#: src/people/classes/player.py:1425
+msgid "Would you like to apply to university?"
+msgstr ""
+
+#: src/people/classes/player.py:1430
+msgid "Your application to university was accepted!"
+msgstr ""
+
+#: src/people/classes/player.py:1432
+msgid "Scholarship"
+msgstr ""
+
+#: src/people/classes/player.py:1433
+msgid "Student Loan"
+msgstr ""
+
+#: src/people/classes/player.py:1434
+msgid "Ask parents to pay"
+msgstr ""
+
+#: src/people/classes/player.py:1440
+msgid "How would you like to pay for your college tuition?"
+msgstr ""
+
+#: src/people/classes/player.py:1446
+msgid "Your scholarship application has been awarded!"
+msgstr ""
+
+#: src/people/classes/player.py:1454
+msgid "Your scholarship application was rejected."
+msgstr ""
+
+#: src/people/classes/player.py:1464
+msgid "Your parents agreed to pay for your university tuition!"
+msgstr ""
+
+#: src/people/classes/player.py:1474
 msgid "Your parents refused to pay for your university tuition."
 msgstr ""
 
-#: src/people/classes/player.py:1101
+#: src/people/classes/player.py:1482
 msgid "You took out a student loan to pay for your university tuition."
 msgstr ""
 
-#: src/people/classes/player.py:1107
+#: src/people/classes/player.py:1488
 msgid "You are now enrolled in university."
 msgstr ""
 
-#: src/people/classes/player.py:1111
+#: src/people/classes/player.py:1492
 msgid "Your application to university was rejected."
 msgstr ""
 
-#: src/people/classes/relationship.py:29
+#: src/people/classes/relationship.py:35
 msgid "he"
 msgstr ""
 
-#: src/people/classes/relationship.py:29
+#: src/people/classes/relationship.py:35
 msgid "she"
 msgstr ""
 
-#: src/people/classes/relationship.py:32
+#: src/people/classes/relationship.py:38
 msgid "his"
 msgstr ""
 
-#: src/people/classes/relationship.py:32 src/people/classes/relationship.py:35
+#: src/people/classes/relationship.py:38 src/people/classes/relationship.py:41
 msgid "her"
 msgstr ""
 
-#: src/people/classes/relationship.py:35
+#: src/people/classes/relationship.py:41
 msgid "him"
 msgstr ""
 
-#: src/people/classes/relationship.py:38
+#: src/people/classes/relationship.py:44
 msgid "he's"
 msgstr ""
 
-#: src/people/classes/relationship.py:38
+#: src/people/classes/relationship.py:44
 msgid "she's"
 msgstr ""
 
-#: src/people/classes/relationship.py:44
+#: src/people/classes/relationship.py:50
 msgid "relationship"
 msgstr ""
 

--- a/src/menus/activities.py
+++ b/src/menus/activities.py
@@ -19,6 +19,10 @@ def activities_menu(player):
                         choices.append(_("Music Time"))
                 if player.age >= 3:
                         choices.append(_("Arts and Crafts"))
+                if 3 <= player.age < 6:
+                        choices.append(_("Early socialization"))
+                        choices.append(_("Everyday learning"))
+                        choices.append(_("Curiosity and exploration"))
                 if player.age >= 4:
                         choices.append(_("Doctor"))
                         if player.age >= 18:
@@ -435,6 +439,46 @@ def activities_menu(player):
                                         if player.has_trait("NERD"):
                                                 player.change_smarts(randint(0, 2))
                         player.did_arts_and_crafts = True
+                elif choice == _("Early socialization"):
+                        selected = True
+                        sayings = [
+                                _("You met with other kids for a playdate and practiced sharing."),
+                                _("You joined a parent-child class at the library."),
+                                _("You visited a toddler gym and made new friends."),
+                                _("You played a collaborative game that taught patience and empathy."),
+                        ]
+                        print(random.choice(sayings))
+                        if not player.did_socialization:
+                                player.change_happiness(randint(2, 5))
+                                player.change_knowledge(randint(1, 2))
+                                player.did_socialization = True
+                elif choice == _("Everyday learning"):
+                        selected = True
+                        sayings = [
+                                _("You helped cook dinner and learned new words."),
+                                _("You watered the garden and talked about how plants grow."),
+                                _("You helped shop for groceries and named the colours of fruits."),
+                                _("You visited a museum and picked up new vocabulary."),
+                        ]
+                        print(random.choice(sayings))
+                        if not player.did_everyday_learning:
+                                player.change_smarts(randint(1, 2))
+                                player.change_knowledge(randint(2, 3))
+                                player.did_everyday_learning = True
+                elif choice == _("Curiosity and exploration"):
+                        selected = True
+                        sayings = [
+                                _("You sorted your toys by color and counted them."),
+                                _("You mixed different colours together to see what would happen."),
+                                _("You planted a seed and watched it begin to sprout."),
+                                _("You asked a big question and heard a simple answer."),
+                        ]
+                        print(random.choice(sayings))
+                        if not player.did_experiment:
+                                player.change_smarts(randint(1, 3))
+                                player.change_happiness(randint(2, 4))
+                                player.change_knowledge(randint(1, 3))
+                                player.did_experiment = True
                 elif choice == _("Listen to music"):
                         selected = True
                         music_categories = [_("pop music"), _("rock music"), _("hip-hop"), _("latin music")]

--- a/src/people/classes/player.py
+++ b/src/people/classes/player.py
@@ -496,6 +496,9 @@ class Player(Person):
 		self.worked_harder = False
 		self.listened_to_music = False
 		self.did_storytime = False
+		self.did_socialization = False
+		self.did_everyday_learning = False
+		self.did_experiment = False
 		self.asked_for_raise = False
 		self.skipped_school = False
 		w = abs(gauss(0, 16))


### PR DESCRIPTION
## Summary
- Expand the activities menu with early socialization, everyday learning, and curiosity-focused options for pre-primary ages
- Track new early childhood activities in the player state
- Refresh translation template to include newly added strings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689087156928832fbb340b08854b0caa