### PR TITLE
Fix spelling errors in user-facing messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Below you will find the process and workflow used to review and merge your chang
 - Wait for the issue to be assigned to you after which you can start working on it.
 
 ## Step 2 : Fork the Project
-- Fork this Repository. This will create a Local Copy of this Repository on your Github Profile. Keep a reference to the original project in `upstream` remote.
+- Fork this Repository. This will create a Local Copy of this Repository on your GitHub Profile. Keep a reference to the original project in `upstream` remote.
 ```
 $ git clone https://github.com/<your-username>/<project-name>
 $ cd <project-name>

--- a/lifesim.pot
+++ b/lifesim.pot
@@ -16,7 +16,7 @@ msgstr ""
 
 
 #: lifesim.py:18
-msgid "An error has occured"
+msgid "An error has occurred"
 msgstr ""
 
 #: lifesim.py:25
@@ -24,7 +24,7 @@ msgid "The above error message has been written to error.log"
 msgstr ""
 
 #: lifesim.py:28
-msgid "Please report this bug on Github"
+msgid "Please report this bug on GitHub"
 msgstr ""
 
 #: lifesim.py:42 src/people/classes/player.py:608

--- a/lifesim.py
+++ b/lifesim.py
@@ -15,7 +15,7 @@ def game_loop(player):
 				if type(e) == PlayerDied:
 					raise
 				clear_screen()
-				print(_("An error has occured"))
+                                print(_("An error has occurred"))
 				import traceback
 				message = "".join(traceback.format_exception(type(e), e, e.__traceback__))
 				print(message)
@@ -25,7 +25,7 @@ def game_loop(player):
 					print(_("The above error message has been written to error.log"))
 				except:
 					pass
-				print(_("Please report this bug on Github"))
+                                print(_("Please report this bug on GitHub"))
 				print("https://github.com/fungamer2-2/Life-Simulator1/issues/new?template=bug_report.md")
 				exit(1)
 			else:
@@ -51,5 +51,5 @@ while True:
 		elif yes_no(_("Would you like to start a new life?")):
 			break
 		else:
-			print(_("Thanks for playing!"))
-			exit()
+                        print(_("Thanks for playing!"))
+                        exit()


### PR DESCRIPTION
## Summary
- fix "occurred" typo and capitalize GitHub in error messages
- keep translation template in sync with corrected strings
- update contributing guide spelling of GitHub

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890945be36c832f951a8211c71435c1